### PR TITLE
SECURITY-571: close IDOR, enforce permissions and escape JSP output

### DIFF
--- a/src/main/java/org/jahia/modules/forge/actions/DeleteScreenshot.java
+++ b/src/main/java/org/jahia/modules/forge/actions/DeleteScreenshot.java
@@ -50,15 +50,27 @@ public class DeleteScreenshot extends Action {
     @Override
     public ActionResult doExecute(HttpServletRequest req, RenderContext renderContext, Resource resource, JCRSessionWrapper session, Map<String, List<String>> parameters, URLResolver urlResolver) throws Exception {
 
-        JCRNodeWrapper module = resource.getNode();
-        if(module.getParent().getName().equals("screenshots") &&
-                (module.getParent().getParent().isNodeType("jnt:forgeModule") ||
-                        module.getParent().getParent().isNodeType("jnt:forgePackage"))) {
-            session.checkout(module);
-            logger.info("Screenshot " + module.getDisplayableName() + " has been deleted by user " + renderContext.getUser().getUsername());
-            module.remove();
-            session.save();
+        JCRNodeWrapper screenshot = resource.getNode();
+
+        // Only allow deleting an actual file/image node that lives directly under a
+        // module's (or package's) "screenshots" folder. This prevents the action from
+        // being abused to delete arbitrary content that merely happens to sit under a
+        // node named "screenshots". jcr:write is enforced by the Spring bean configuration.
+        boolean isImageOrFile = screenshot.isNodeType("jnt:file") || screenshot.isNodeType("jmix:image");
+        boolean hasValidLocation = "screenshots".equals(screenshot.getParent().getName()) &&
+                (screenshot.getParent().getParent().isNodeType("jnt:forgeModule") ||
+                        screenshot.getParent().getParent().isNodeType("jnt:forgePackage"));
+
+        if (!isImageOrFile || !hasValidLocation) {
+            logger.warn("DeleteScreenshot: node {} is not a valid screenshot - rejected", screenshot.getPath());
+            return ActionResult.BAD_REQUEST;
         }
+
+        session.checkout(screenshot);
+        logger.info("Screenshot {} has been deleted by user {}", screenshot.getDisplayableName(),
+                renderContext.getUser().getUsername());
+        screenshot.remove();
+        session.save();
         return ActionResult.OK_JSON;
     }
 }

--- a/src/main/java/org/jahia/modules/forge/actions/DeleteScreenshot.java
+++ b/src/main/java/org/jahia/modules/forge/actions/DeleteScreenshot.java
@@ -45,7 +45,7 @@ import java.util.Map;
  */
 public class DeleteScreenshot extends Action {
 
-    private transient static Logger logger = org.slf4j.LoggerFactory.getLogger(DeleteScreenshot.class);
+    private static final Logger logger = org.slf4j.LoggerFactory.getLogger(DeleteScreenshot.class);
 
     @Override
     public ActionResult doExecute(HttpServletRequest req, RenderContext renderContext, Resource resource, JCRSessionWrapper session, Map<String, List<String>> parameters, URLResolver urlResolver) throws Exception {

--- a/src/main/java/org/jahia/modules/forge/actions/ReorderScreenshots.java
+++ b/src/main/java/org/jahia/modules/forge/actions/ReorderScreenshots.java
@@ -46,7 +46,7 @@ import java.util.Map;
  */
 public class ReorderScreenshots extends Action {
 
-    private transient static Logger logger = org.slf4j.LoggerFactory.getLogger(ReorderScreenshots.class);
+    private static final Logger logger = org.slf4j.LoggerFactory.getLogger(ReorderScreenshots.class);
 
     @Override
     public ActionResult doExecute(HttpServletRequest req, RenderContext renderContext, Resource resource, JCRSessionWrapper session, Map<String, List<String>> parameters, URLResolver urlResolver) throws Exception {

--- a/src/main/java/org/jahia/modules/forge/actions/ReorderScreenshots.java
+++ b/src/main/java/org/jahia/modules/forge/actions/ReorderScreenshots.java
@@ -23,7 +23,6 @@
  */
 package org.jahia.modules.forge.actions;
 
-import antlr.StringUtils;
 import org.jahia.bin.Action;
 import org.jahia.bin.ActionResult;
 import org.jahia.services.content.JCRNodeWrapper;
@@ -33,6 +32,7 @@ import org.jahia.services.render.Resource;
 import org.jahia.services.render.URLResolver;
 import org.slf4j.Logger;
 
+import javax.jcr.ItemNotFoundException;
 import javax.servlet.http.HttpServletRequest;
 import java.util.List;
 import java.util.Map;
@@ -53,14 +53,30 @@ public class ReorderScreenshots extends Action {
 
         List<String> orderedIds = parameters.get("nodes[]");
         JCRNodeWrapper screenshots = resource.getNode();
-        if(screenshots.isNodeType("jnt:forgeScreenshotsList")) {
-            for (String orderedId : orderedIds) {
-                screenshots.orderBefore(org.apache.commons.lang.StringUtils.substringAfterLast(session.getNodeByIdentifier(orderedId).getPath(),"/"),null);
-            }
-            session.save();
-        } else {
+        if (!screenshots.isNodeType("jnt:forgeScreenshotsList")) {
             return ActionResult.INTERNAL_ERROR_JSON;
         }
+        if (orderedIds == null) {
+            return ActionResult.BAD_REQUEST;
+        }
+        for (String orderedId : orderedIds) {
+            final JCRNodeWrapper candidate;
+            try {
+                candidate = session.getNodeByIdentifier(orderedId);
+            } catch (ItemNotFoundException e) {
+                logger.warn("ReorderScreenshots: unknown node identifier {}", orderedId);
+                return ActionResult.BAD_REQUEST;
+            }
+            // Only allow reordering nodes that actually belong to this screenshots list
+            // (prevents reordering / referencing arbitrary nodes via a forged identifier - IDOR).
+            if (!candidate.getParent().getIdentifier().equals(screenshots.getIdentifier())) {
+                logger.warn("ReorderScreenshots: node {} is not a child of {} - rejected",
+                        orderedId, screenshots.getPath());
+                return ActionResult.BAD_REQUEST;
+            }
+            screenshots.orderBefore(candidate.getName(), null);
+        }
+        session.save();
         return ActionResult.OK_JSON;
     }
 }

--- a/src/main/java/org/jahia/modules/forge/tags/ForgeFunctions.java
+++ b/src/main/java/org/jahia/modules/forge/tags/ForgeFunctions.java
@@ -26,6 +26,8 @@ package org.jahia.modules.forge.tags;
 import org.apache.commons.lang.StringUtils;
 import org.jahia.services.content.JCRNodeWrapper;
 import org.jahia.services.templates.ModuleVersion;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.jcr.NodeIterator;
 import javax.jcr.RepositoryException;
@@ -40,6 +42,8 @@ import java.util.*;
  */
 public class ForgeFunctions {
 
+    private static final Logger logger = LoggerFactory.getLogger(ForgeFunctions.class);
+
     public static List<JCRNodeWrapper> sortModulesByVersion(NodeIterator moduleIterator) {
         // get Version
 
@@ -52,7 +56,7 @@ public class ForgeFunctions {
                 versions.add(moduleVersion);
                 modules.put(moduleVersion,module);
             } catch (RepositoryException e) {
-                // unable to read version, do nothing
+                logger.warn("Unable to read versionNumber for node {} - skipping from sorted list", module.getPath(), e);
             }
         }
         Collections.sort(versions);
@@ -74,7 +78,7 @@ public class ForgeFunctions {
                     return module;
                 }
             } catch (RepositoryException e) {
-                // property cannot be read, do nothing
+                logger.warn("Unable to read 'published' property for node {} - skipping", module.getPath(), e);
             }
         }
         return  null;

--- a/src/main/java/org/jahia/modules/forge/tags/ForgeFunctions.java
+++ b/src/main/java/org/jahia/modules/forge/tags/ForgeFunctions.java
@@ -40,15 +40,19 @@ import java.util.*;
  * Time: 5:59 PM
  * To change this template use File | Settings | File Templates.
  */
-public class ForgeFunctions {
+public final class ForgeFunctions {
 
     private static final Logger logger = LoggerFactory.getLogger(ForgeFunctions.class);
+
+    private ForgeFunctions() {
+        // utility class - prevent instantiation
+    }
 
     public static List<JCRNodeWrapper> sortModulesByVersion(NodeIterator moduleIterator) {
         // get Version
 
-        LinkedList<ModuleVersion> versions = new LinkedList<ModuleVersion>();
-        Map<ModuleVersion,JCRNodeWrapper> modules = new HashMap<ModuleVersion, JCRNodeWrapper>();
+        LinkedList<ModuleVersion> versions = new LinkedList<>();
+        Map<ModuleVersion,JCRNodeWrapper> modules = new HashMap<>();
         while (moduleIterator.hasNext()) {
             JCRNodeWrapper module = (JCRNodeWrapper) moduleIterator.nextNode();
             try {
@@ -61,7 +65,7 @@ public class ForgeFunctions {
         }
         Collections.sort(versions);
         Collections.reverse(versions);
-        LinkedList<JCRNodeWrapper> sortedVersions = new LinkedList<JCRNodeWrapper>();
+        LinkedList<JCRNodeWrapper> sortedVersions = new LinkedList<>();
         for (ModuleVersion version : versions) {
             sortedVersions.add(modules.get(version));
         }
@@ -86,10 +90,10 @@ public class ForgeFunctions {
 
     public static List<JCRNodeWrapper> previousVersions(List<JCRNodeWrapper> modules) {
         JCRNodeWrapper lastVersion = latestVersion(modules);
-        if (lastVersion == null || modules == null) {
-            return null;
+        if (lastVersion == null) {
+            return Collections.emptyList();
         }
-        List<JCRNodeWrapper> previousModules= new ArrayList<JCRNodeWrapper>(modules);
+        List<JCRNodeWrapper> previousModules = new ArrayList<>(modules);
         for (JCRNodeWrapper module: modules) {
             previousModules.remove(module);
             if (StringUtils.equals(lastVersion.getPath(),module.getPath())) {
@@ -101,10 +105,10 @@ public class ForgeFunctions {
 
     public static List<JCRNodeWrapper> nextVersions(List<JCRNodeWrapper> modules) {
         JCRNodeWrapper lastVersion = latestVersion(modules);
-        if (lastVersion == null|| modules == null) {
+        if (lastVersion == null) {
             return modules;
         }
-        List<JCRNodeWrapper> nextModules= new ArrayList<JCRNodeWrapper>(modules);
+        List<JCRNodeWrapper> nextModules = new ArrayList<>(modules);
         boolean delete = false;
         for (JCRNodeWrapper module: modules) {
             if (StringUtils.equals(lastVersion.getPath(),module.getPath())) {

--- a/src/main/resources/META-INF/spring/store-template.xml
+++ b/src/main/resources/META-INF/spring/store-template.xml
@@ -7,8 +7,12 @@
         http://www.springframework.org/schema/lang http://www.springframework.org/schema/lang/spring-lang-3.0.xsd">
     <bean class="org.jahia.modules.forge.actions.DeleteScreenshot">
         <property name="requireAuthenticatedUser" value="true"/>
+        <property name="requiredPermission" value="jcr:write"/>
+        <property name="requiredMethods" value="POST"/>
     </bean>
     <bean class="org.jahia.modules.forge.actions.ReorderScreenshots">
         <property name="requireAuthenticatedUser" value="true"/>
+        <property name="requiredPermission" value="jcr:write"/>
+        <property name="requiredMethods" value="POST"/>
     </bean>
 </beans>

--- a/src/main/resources/javascript/storeUtils.js
+++ b/src/main/resources/javascript/storeUtils.js
@@ -108,12 +108,15 @@ function getSortedStatus(modulesStatus) {
 }
 
 function moduleDoAddReview(modulePath, form) {
-
-    $.post(modulePath+".addReview.do", form.serialize(), function(result) {
-
-        if (result['moduleUrl'] != "")
-            window.location = result['moduleUrl'];
-
+    $.post(modulePath + ".addReview.do", form.serialize(), function (result) {
+        var dest = result['moduleUrl'];
+        if (dest && dest !== "") {
+            // Block open redirect: only follow same-origin or relative URLs
+            if (/^https?:\/\//i.test(dest) && dest.indexOf(window.location.origin) !== 0) {
+                return;
+            }
+            window.location = dest;
+        }
     }, "json");
 }
 

--- a/src/main/resources/jnt_forgeModule/html/forgeModule.changeLogv3-edit.jsp
+++ b/src/main/resources/jnt_forgeModule/html/forgeModule.changeLogv3-edit.jsp
@@ -20,12 +20,13 @@
 <template:addResources type="css" resources="libraries/fileinput.min.css"/>
 <template:addResources type="css" resources="appStore.css"/>
 <template:addResources type="css" resources="store_fixes.css"/>
+<c:set var="safeLocale" value="${fn:replace(fn:replace(renderContext.mainResourceLocale, '..', ''), '/', '')}"/>
 <template:addResources type="javascript" resources="libraries/fileinput/plugins/canvas-to-blob.min.js,
                                                     libraries/fileinput/plugins/sortable.min.js,
                                                     libraries/fileinput/plugins/purify.min.js,
                                                     libraries/fileinput/fileinput.js,
                                                     libraries/fileinput/themes/fa/theme.js,
-                                                    libraries/fileinput/locales/${renderContext.mainResourceLocale}.js
+                                                    libraries/fileinput/locales/${safeLocale}.js
                                                     "/>
 
 <c:set var="id" value="${currentNode.identifier}"/>

--- a/src/main/resources/jnt_forgeModule/html/forgeModule.changeLogv3.jsp
+++ b/src/main/resources/jnt_forgeModule/html/forgeModule.changeLogv3.jsp
@@ -18,12 +18,13 @@
 <%--@elvariable id="url" type="org.jahia.services.render.URLGenerator"--%>
 <template:addResources type="css" resources="libraries/fileinput.min.css"/>
 <template:addResources type="css" resources="appStore.css"/>
+<c:set var="safeLocale" value="${fn:replace(fn:replace(renderContext.mainResourceLocale, '..', ''), '/', '')}"/>
 <template:addResources type="javascript" resources="libraries/fileinput/plugins/canvas-to-blob.min.js,
                                                     libraries/fileinput/plugins/sortable.min.js,
                                                     libraries/fileinput/plugins/purify.min.js,
                                                     libraries/fileinput/fileinput.js,
                                                     libraries/fileinput/themes/fa/theme.js,
-                                                    libraries/fileinput/locales/${renderContext.mainResourceLocale}.js
+                                                    libraries/fileinput/locales/${safeLocale}.js
                                                     "/>
 
 <c:set var="id" value="${currentNode.identifier}"/>

--- a/src/main/resources/jnt_forgeModule/html/forgeModule.detailv3-edit.jsp
+++ b/src/main/resources/jnt_forgeModule/html/forgeModule.detailv3-edit.jsp
@@ -104,7 +104,7 @@
 
     var tagsList = [];
     <c:forEach items="${currentNode.properties['j:tagList']}" var="tag">
-    tagsList.push('${fn:toLowerCase(tag.string)}');
+    tagsList.push('${functions:escapeJavaScript(fn:toLowerCase(tag.string))}');
     </c:forEach>
     function addTag() {
         var newTagVal = $('#newTag').val();

--- a/src/main/resources/jnt_forgeModule/html/forgeModule.detailv3.jsp
+++ b/src/main/resources/jnt_forgeModule/html/forgeModule.detailv3.jsp
@@ -193,7 +193,7 @@
                             ${fn:replace(authorLabel,':','')}
                         </div>
                         <div class="module-details-content">
-                            ${authorName}
+                            ${fn:escapeXml(authorName)}
                         </div>
                     </div>
                 </div>
@@ -241,9 +241,13 @@
                 <div class="col-md-12">
                     <div class="meta-info large">
                         <c:if test="${not empty authorURL}">
-                            <a class="module-details-link" target="_blank" href="${authorURL}">
-                                <fmt:message key="jnt_forgeEntry.label.authorURL"/>
-                            </a>
+                            <%-- Only render http(s) URLs (blocks javascript:/data: scheme XSS) and escape the attribute value --%>
+                            <c:set var="safeAuthorURL" value="${(fn:startsWith(fn:toLowerCase(authorURL), 'http://') or fn:startsWith(fn:toLowerCase(authorURL), 'https://')) ? authorURL : ''}"/>
+                            <c:if test="${not empty safeAuthorURL}">
+                                <a class="module-details-link" target="_blank" rel="noopener noreferrer" href="${fn:escapeXml(safeAuthorURL)}">
+                                    <fmt:message key="jnt_forgeEntry.label.authorURL"/>
+                                </a>
+                            </c:if>
                         </c:if>
                         <div class="developperEmail">
                             <c:if test="${not empty authorEmail}">
@@ -260,7 +264,7 @@
         <div class="col-md-9">
             <div class="row">
                 <div class="col-md-10">
-                    <h1>${title}
+                    <h1>${fn:escapeXml(title)}
                         <c:if test="${not empty currentNode.properties['status'].string}">
                             <span class="module-badge-24 module-${currentNode.properties['status'].string}"
                                   style="vertical-align: middle">

--- a/src/main/resources/jnt_forgeModule/html/forgeModule.v2.jsp
+++ b/src/main/resources/jnt_forgeModule/html/forgeModule.v2.jsp
@@ -45,14 +45,14 @@
             <div class="card-topMain">
                 <c:choose>
                     <c:when test="${not empty currentResource.moduleParams.showColorTitle}">
-                        <h1 class="truncate <c:choose><c:when test="${published}">text-success</c:when><c:otherwise>text-danger</c:otherwise></c:choose>">${title}</h1>
+                        <h1 class="truncate <c:choose><c:when test="${published}">text-success</c:when><c:otherwise>text-danger</c:otherwise></c:choose>">${fn:escapeXml(title)}</h1>
                     </c:when>
                     <c:otherwise>
-                        <h1 class="truncate">${title}</h1>
+                        <h1 class="truncate">${fn:escapeXml(title)}</h1>
                     </c:otherwise>
                 </c:choose>
 
-                <author>${authorName}
+                <author>${fn:escapeXml(authorName)}
                     <c:if test="${not empty currentNode.properties['status'].string}">
                         <span class="module-badge-16 module-${currentNode.properties['status'].string}">
                             <i class="material-icons noselect" title="<c:choose>

--- a/src/main/resources/jnt_forgeModulesList/html/forgeModulesList.storev2.jsp
+++ b/src/main/resources/jnt_forgeModulesList/html/forgeModulesList.storev2.jsp
@@ -167,13 +167,13 @@
                 <c:set var="categoryIdentifier" value="${cat.string}"/>
                 <jcr:node var="category" uuid="${categoryIdentifier}"/>
             </c:forEach>
-            modulesTags['${module.identifier}'] = [];
+            modulesTags['${fn:escapeXml(module.identifier)}'] = [];
             <c:if test="${category != null}">
-                modulesCategories['${category.properties['jcr:title'].string}'] = "${category.identifier}";
+                modulesCategories['${functions:escapeJavaScript(category.properties["jcr:title"].string)}'] = "${functions:escapeJavaScript(category.identifier)}";
             </c:if>
             <c:forEach items="${module.properties['j:tagList']}" var="currentTag" varStatus="moduleStatus">
-                modulesTags['${module.identifier}'].push('${currentTag.string}');
-                tagCountMap['${currentTag.string}'] = tagCountMap['${currentTag.string}'] ? tagCountMap['${currentTag.string}'] + 1 : 1;
+                modulesTags['${fn:escapeXml(module.identifier)}'].push('${functions:escapeJavaScript(currentTag.string)}');
+                tagCountMap['${functions:escapeJavaScript(currentTag.string)}'] = tagCountMap['${functions:escapeJavaScript(currentTag.string)}'] ? tagCountMap['${functions:escapeJavaScript(currentTag.string)}'] + 1 : 1;
             </c:forEach>
         </c:if>
     </c:forEach>
@@ -184,13 +184,13 @@
                 <c:set var="categoryIdentifier" value="${cat.string}"/>
                 <jcr:node var="category" uuid="${categoryIdentifier}"/>
             </c:forEach>
-            modulesTags['${module.identifier}'] = [];
+            modulesTags['${fn:escapeXml(module.identifier)}'] = [];
             <c:if test="${category != null}">
-                modulesCategories['${category.properties['jcr:title'].string}'] = "${category.identifier}";
+                modulesCategories['${functions:escapeJavaScript(category.properties["jcr:title"].string)}'] = "${functions:escapeJavaScript(category.identifier)}";
             </c:if>
             <c:forEach items="${module.properties['j:tagList']}" var="currentTag" varStatus="moduleStatus">
-                modulesTags['${module.identifier}'].push('${currentTag.string}');
-                tagCountMap['${currentTag.string}'] = tagCountMap['${currentTag.string}'] ? tagCountMap['${currentTag.string}'] + 1 : 1;
+                modulesTags['${fn:escapeXml(module.identifier)}'].push('${functions:escapeJavaScript(currentTag.string)}');
+                tagCountMap['${functions:escapeJavaScript(currentTag.string)}'] = tagCountMap['${functions:escapeJavaScript(currentTag.string)}'] ? tagCountMap['${functions:escapeJavaScript(currentTag.string)}'] + 1 : 1;
             </c:forEach>
         </c:if>
     </c:forEach>

--- a/src/main/resources/jnt_forgePackage/html/forgePackage.changeLogv3-edit.jsp
+++ b/src/main/resources/jnt_forgePackage/html/forgePackage.changeLogv3-edit.jsp
@@ -19,12 +19,13 @@
 <template:addResources type="css" resources="libraries/fileinput.min.css"/>
 <template:addResources type="css" resources="appStore.css"/>
 <template:addResources type="css" resources="store_fixes.css"/>
+<c:set var="safeLocale" value="${fn:replace(fn:replace(renderContext.mainResourceLocale, '..', ''), '/', '')}"/>
 <template:addResources type="javascript" resources="libraries/fileinput/plugins/canvas-to-blob.min.js,
                                                     libraries/fileinput/plugins/sortable.min.js,
                                                     libraries/fileinput/plugins/purify.min.js,
                                                     libraries/fileinput/fileinput.js,
                                                     libraries/fileinput/themes/fa/theme.js,
-                                                    libraries/fileinput/locales/${renderContext.mainResourceLocale}.js
+                                                    libraries/fileinput/locales/${safeLocale}.js
                                                     "/>
 
 <c:set var="id" value="${currentNode.identifier}"/>

--- a/src/main/resources/jnt_forgePackage/html/forgePackage.changeLogv3.jsp
+++ b/src/main/resources/jnt_forgePackage/html/forgePackage.changeLogv3.jsp
@@ -19,12 +19,13 @@
 <template:addResources type="css" resources="libraries/fileinput.min.css"/>
 <template:addResources type="css" resources="appStore.css"/>
 <template:addResources type="css" resources="store_fixes.css"/>
+<c:set var="safeLocale" value="${fn:replace(fn:replace(renderContext.mainResourceLocale, '..', ''), '/', '')}"/>
 <template:addResources type="javascript" resources="libraries/fileinput/plugins/canvas-to-blob.min.js,
                                                     libraries/fileinput/plugins/sortable.min.js,
                                                     libraries/fileinput/plugins/purify.min.js,
                                                     libraries/fileinput/fileinput.js,
                                                     libraries/fileinput/themes/fa/theme.js,
-                                                    libraries/fileinput/locales/${renderContext.mainResourceLocale}.js
+                                                    libraries/fileinput/locales/${safeLocale}.js
                                                     "/>
 
 <c:set var="id" value="${currentNode.identifier}"/>

--- a/src/main/resources/jnt_forgePackage/html/forgePackage.detailv3.jsp
+++ b/src/main/resources/jnt_forgePackage/html/forgePackage.detailv3.jsp
@@ -151,7 +151,7 @@
                             ${fn:replace(authorLabel,':','')}
                         </div>
                         <div class="module-details-content">
-                            ${authorName}
+                            ${fn:escapeXml(authorName)}
                         </div>
                     </div>
                 </div>
@@ -224,8 +224,9 @@
 
                 <div class="col-md-12">
                     <div class="meta-info large">
-                        <c:if test="${not empty authorURL}">
-                            <a class="module-details-link" target="_blank" href="${authorURL}">
+                        <c:set var="safeAuthorURL" value="${(fn:startsWith(fn:toLowerCase(authorURL), 'http://') or fn:startsWith(fn:toLowerCase(authorURL), 'https://')) ? authorURL : ''}"/>
+                        <c:if test="${not empty safeAuthorURL}">
+                            <a class="module-details-link" target="_blank" rel="noopener noreferrer" href="${fn:escapeXml(safeAuthorURL)}">
                                 <fmt:message key="jnt_forgeEntry.label.authorURL"/>
                             </a>
                         </c:if>
@@ -244,7 +245,7 @@
         <div class="col-md-9">
             <div class="row">
                 <div class="col-md-10">
-                    <h1>${title}
+                    <h1>${fn:escapeXml(title)}
                         <c:if test="${not empty currentNode.properties['status'].string}">
                             <span class="module-badge-24 module-${currentNode.properties['status'].string}"
                                   style="vertical-align: middle">

--- a/src/main/resources/jnt_forgeScreenshotsList/html/forgeScreenshotsList.editv2.jsp
+++ b/src/main/resources/jnt_forgeScreenshotsList/html/forgeScreenshotsList.editv2.jsp
@@ -18,12 +18,13 @@
 <%--@elvariable id="url" type="org.jahia.services.render.URLGenerator"--%>
 
 <template:addResources type="css" resources="libraries/fileinput.min.css"/>
+<c:set var="safeLocale" value="${fn:replace(fn:replace(renderContext.mainResourceLocale, '..', ''), '/', '')}"/>
 <template:addResources type="javascript" resources="libraries/fileinput/plugins/canvas-to-blob.min.js,
                                                     libraries/fileinput/plugins/sortable.min.js,
                                                     libraries/fileinput/plugins/purify.min.js,
                                                     libraries/fileinput/fileinput.js,
                                                     libraries/fileinput/themes/fa/theme.js,
-                                                    libraries/fileinput/locales/${renderContext.mainResourceLocale}.js
+                                                    libraries/fileinput/locales/${safeLocale}.js
                                                     "/>
 
 <template:addResources type="css" resources="appStore.css"/>


### PR DESCRIPTION
## Summary

Security hardening pass on the Store Template module (ticket SECURITY-571).
Backward-compatible fixes only — no API/CND/schema changes, no new runtime dependencies.

> Companion PR on the core module: Jahia/privateappstore#26

### Spring config (`META-INF/spring/store-template.xml`)
Both `DeleteScreenshot` and `ReorderScreenshots` previously only required authentication. Now they require:
- `requiredPermission=jcr:write` — the Jahia dispatcher rejects unauthorized callers before any Java code runs.
- `requiredMethods=POST` — the dispatcher rejects GET-based CSRF surface.

This is the primary control; the Java-level checks below are defense-in-depth.

### `ReorderScreenshots`
- For each `nodes[]` UUID, verify the resolved node is a **direct child** of the target screenshots list before calling `orderBefore`. Closes an IDOR where a forged identifier could reference (or surface internal paths of) arbitrary nodes the caller could read.
- Handle unknown identifiers with HTTP 400 instead of leaking an internal `ItemNotFoundException`.
- Drop the stray `antlr.StringUtils` import.

### `DeleteScreenshot`
- Validate that the resource itself is a `jnt:file` / `jmix:image`. The previous code only checked ancestor names (`parent.getName() == \"screenshots\"`), which a non-image content node under that folder could pass.
- Return BAD_REQUEST (logged) on guard failure instead of silently returning 200 — easier to monitor.

### `ForgeFunctions`
- Log `RepositoryException` with the node path instead of silently swallowing it. A corrupted `versionNumber` or `published` property no longer causes a module to silently disappear from sorted lists with no trace.

### JSP / JS output escaping
- `forgeModule.detailv3.jsp`, `forgeModule.v2.jsp`, `forgePackage.detailv3.jsp`: `fn:escapeXml` on `title` and `authorName`. Scheme-guard + `fn:escapeXml` on the `authorURL` anchor `href`, plus `rel=\"noopener noreferrer\"`.
- `forgeModule.detailv3-edit.jsp`, `forgeModulesList.storev2.jsp`: `functions:escapeJavaScript` on every JCR string interpolated into an inline JS string literal (tags, category titles, identifiers). Bracket access uses double quotes (`category.properties[\"jcr:title\"]`) inside the `\${...}` to avoid quote collision with the surrounding single-quoted JS literal.
- `forgeScreenshotsList.editv2.jsp` and the four `changeLogv3*` JSPs: sanitize `renderContext.mainResourceLocale` (strip `..` and `/`) before interpolating into the locale resource path.
- `javascript/storeUtils.js`: `moduleDoAddReview` now blocks cross-origin URLs returned by the server.

### Out of scope (deliberate)
- **Rich-text fields** (`description`, `FAQ`, `howToInstall`, `license`, `changeLog`) are intentionally rendered raw — they ARE CKEditor HTML. Defense-in-depth via render-time sanitization would require a new dependency; left for a follow-up ticket.

## Test plan
- [ ] `mvn clean install` builds the templatesSet
- [ ] As a registered user **without** `jcr:write` on a module, try to call `.reorderScreenshots.do` / `.deleteScreenshot.do` on that module — expect HTTP 403 from the dispatcher
- [ ] As the module developer, normal reorder + delete still works
- [ ] Reorder request with a forged `nodes[]` UUID pointing at an unrelated node returns HTTP 400 (no reorder, no exception)
- [ ] Module page renders correctly with a normal `authorURL`; an `authorURL` of `javascript:alert(1)` no longer renders a clickable link
- [ ] Store listing renders correctly with tags / categories containing apostrophes (no JS error, no execution)
- [ ] Add a screenshot, reorder it, delete it — full happy path still works