### PR TITLE
SECURITY-571 follow-ups: login error UX, status filter fix, footer icons, language selector

### DIFF
--- a/settings/locales/en.json
+++ b/settings/locales/en.json
@@ -28,7 +28,7 @@
     "cookies": "Cookie Policy",
     "rss": "RSS feed of new modules",
     "legalNav": "Legal",
-    "socialNav": "Social media"
+    "followNav": "Follow us"
   },
   "store": {
     "filter": {

--- a/settings/locales/en.json
+++ b/settings/locales/en.json
@@ -8,7 +8,9 @@
       "signIn": "Log in",
       "signOut": "Log out",
       "username": "Username",
-      "password": "Password"
+      "password": "Password",
+      "invalidCredentials": "Invalid username or password.",
+      "accountLocked": "This account is locked. Contact an administrator."
     },
     "menu": {
       "open": "Open menu",

--- a/settings/locales/en.json
+++ b/settings/locales/en.json
@@ -19,6 +19,9 @@
     "nav": {
       "label": "Main navigation"
     },
+    "language": {
+      "label": "Language"
+    },
     "skipToMain": "Skip to main content"
   },
   "footer": {

--- a/settings/locales/fr.json
+++ b/settings/locales/fr.json
@@ -8,7 +8,9 @@
       "signIn": "Connexion",
       "signOut": "Déconnexion",
       "username": "Nom d'utilisateur",
-      "password": "Mot de passe"
+      "password": "Mot de passe",
+      "invalidCredentials": "Nom d'utilisateur ou mot de passe incorrect.",
+      "accountLocked": "Ce compte est verrouillé. Contactez un administrateur."
     },
     "menu": {
       "open": "Ouvrir le menu",

--- a/settings/locales/fr.json
+++ b/settings/locales/fr.json
@@ -28,7 +28,7 @@
     "cookies": "Politique relative aux cookies",
     "rss": "Flux RSS des nouveaux modules",
     "legalNav": "Mentions légales",
-    "socialNav": "Réseaux sociaux"
+    "followNav": "Suivez-nous"
   },
   "store": {
     "filter": {

--- a/settings/locales/fr.json
+++ b/settings/locales/fr.json
@@ -19,6 +19,9 @@
     "nav": {
       "label": "Navigation principale"
     },
+    "language": {
+      "label": "Langue"
+    },
     "skipToMain": "Aller au contenu principal"
   },
   "footer": {

--- a/src/components/ForgeModulesList/default.server.tsx
+++ b/src/components/ForgeModulesList/default.server.tsx
@@ -45,7 +45,9 @@ function buildWhere(basePath: string, term: string, statuses: string[], categori
     clauses.push(`LOWER(e.[jcr:title]) LIKE '%${likeTerm}%'`);
   }
   if (statuses.length > 0) {
-    const statusOr = statuses.map((s) => `e.[status] = '${sql(s)}'`).join(" OR ");
+    // Match case-insensitively: the facet submits the lowercase choicelist key, but migrated
+    // data may store the status with different casing (e.g. "Community" vs "community").
+    const statusOr = statuses.map((s) => `LOWER(e.[status]) = '${sql(s.toLowerCase())}'`).join(" OR ");
     clauses.push(`(${statusOr})`);
   }
   if (categories.length > 0) {

--- a/src/components/chrome/Footer.module.css
+++ b/src/components/chrome/Footer.module.css
@@ -64,40 +64,4 @@
   box-shadow: var(--ring);
 }
 
-/* RSS feed: a small pill so the feed is discoverable next to the social links. */
-.feed {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4rem;
-  padding: 0.3rem 0.7rem;
-  border: 1px solid var(--color-border);
-  border-radius: 999px;
-  color: var(--color-text-muted);
-  font-weight: 600;
-  font-size: 0.8rem;
-  letter-spacing: 0.02em;
-  transition: color 150ms var(--ease), border-color 150ms var(--ease),
-    background 150ms var(--ease);
-}
-
-.feed:hover {
-  color: var(--color-accent);
-  border-color: var(--color-accent);
-  background: var(--color-surface-2);
-  text-decoration: none;
-}
-
-.feed:focus-visible {
-  outline: 2px solid var(--color-accent);
-  outline-offset: 2px;
-}
-
-/* Canonical RSS orange on the glyph only (decorative); the "RSS" text carries the name. */
-.rssIcon {
-  flex: none;
-  color: #e8590c;
-}
-
-.feedLabel {
-  line-height: 1;
-}
+/* The RSS feed link reuses .socialLink (icon-only, same square tap target as the socials). */

--- a/src/components/chrome/Footer.module.css
+++ b/src/components/chrome/Footer.module.css
@@ -40,7 +40,28 @@
 }
 
 .social {
-  gap: 0.25rem 0.85rem;
+  gap: 0.25rem 0.5rem;
+}
+
+/* Social brand icons: square tap targets (≥24×24 for the target-size rule), muted →
+   accent on hover, with a subtle surface so the hit area reads as a button. */
+.socialLink {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: var(--radius);
+  color: var(--color-text-muted);
+}
+.socialLink:hover {
+  color: var(--color-accent);
+  background: var(--color-surface-2);
+  text-decoration: none;
+}
+.socialLink:focus-visible {
+  outline: none;
+  box-shadow: var(--ring);
 }
 
 /* RSS feed: a small pill so the feed is discoverable next to the social links. */

--- a/src/components/chrome/Footer.tsx
+++ b/src/components/chrome/Footer.tsx
@@ -134,7 +134,7 @@ export function Footer(): JSX.Element {
             </a>
           ))}
         </nav>
-        <nav className={styles.social} aria-label={t("footer.socialNav")}>
+        <nav className={styles.social} aria-label={t("footer.followNav")}>
           {social.map((s) => (
             <a
               key={s.label}
@@ -147,18 +147,18 @@ export function Footer(): JSX.Element {
               <SocialIcon name={s.label} />
             </a>
           ))}
+          {rssUrl && (
+            <a
+              className={styles.socialLink}
+              href={rssUrl}
+              aria-label={t("footer.rss")}
+              title={t("footer.rss")}
+              data-rss-feed=""
+            >
+              <RssIcon />
+            </a>
+          )}
         </nav>
-        {rssUrl && (
-          <a
-            className={styles.socialLink}
-            href={rssUrl}
-            aria-label={t("footer.rss")}
-            title={t("footer.rss")}
-            data-rss-feed=""
-          >
-            <RssIcon />
-          </a>
-        )}
       </div>
     </footer>
   );

--- a/src/components/chrome/Footer.tsx
+++ b/src/components/chrome/Footer.tsx
@@ -75,6 +75,32 @@ function RssIcon(): JSX.Element {
 }
 
 /**
+ * Brand glyphs for the social links (Simple Icons paths, 24×24, drawn in currentColor).
+ * Decorative — each link carries the platform name as its aria-label.
+ */
+const SOCIAL_ICONS: Record<string, string> = {
+  Facebook:
+    "M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z",
+  LinkedIn:
+    "M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 01-2.063-2.065 2.064 2.064 0 112.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z",
+  Twitter:
+    "M23.953 4.57a10 10 0 01-2.825.775 4.958 4.958 0 002.163-2.723c-.951.555-2.005.959-3.127 1.184a4.92 4.92 0 00-8.384 4.482C7.69 8.095 4.067 6.13 1.64 3.162a4.822 4.822 0 00-.666 2.475c0 1.71.87 3.213 2.188 4.096a4.904 4.904 0 01-2.228-.616v.06a4.923 4.923 0 003.946 4.827 4.996 4.996 0 01-2.212.085 4.936 4.936 0 004.604 3.417 9.867 9.867 0 01-6.102 2.105c-.39 0-.779-.023-1.17-.067a13.995 13.995 0 007.557 2.209c9.053 0 13.998-7.496 13.998-13.985 0-.21 0-.42-.015-.63A9.935 9.935 0 0024 4.59z",
+  YouTube:
+    "M23.498 6.186a3.016 3.016 0 00-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 00.502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 002.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 002.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z",
+};
+
+/** A social brand icon by platform name; null for an unknown platform. */
+function SocialIcon({ name }: { name: string }): JSX.Element | null {
+  const path = SOCIAL_ICONS[name];
+  if (!path) return null;
+  return (
+    <svg viewBox="0 0 24 24" width="20" height="20" aria-hidden="true" focusable="false" fill="currentColor">
+      <path d={path} />
+    </svg>
+  );
+}
+
+/**
  * Store footer: copyright + legal and social links. Content is read from the
  * site's forge settings (Store administration → Settings); each value falls back
  * to the Jahia default when the site has not configured it.
@@ -112,8 +138,15 @@ export function Footer(): JSX.Element {
         </nav>
         <nav className={styles.social} aria-label={t("footer.socialNav")}>
           {social.map((s) => (
-            <a key={s.label} href={s.href} target="_blank" rel="noopener noreferrer">
-              {s.label}
+            <a
+              key={s.label}
+              className={styles.socialLink}
+              href={s.href}
+              aria-label={s.label}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <SocialIcon name={s.label} />
             </a>
           ))}
         </nav>

--- a/src/components/chrome/Footer.tsx
+++ b/src/components/chrome/Footer.tsx
@@ -61,15 +61,13 @@ function feedUrl(site: JCRNodeWrapper): string | null {
   }
 }
 
-/** Standard RSS glyph (dot + two broadcast arcs). Decorative; the link carries the name. */
+/** Standard RSS glyph (dot + two broadcast arcs). Decorative (currentColor, sized to match the
+ * social icons); the link carries the name via its aria-label. */
 function RssIcon(): JSX.Element {
   return (
-    <svg className={styles.rssIcon} viewBox="0 0 24 24" width="18" height="18" aria-hidden="true" focusable="false">
-      <circle cx="6.18" cy="17.82" r="2.18" fill="currentColor" />
-      <path
-        fill="currentColor"
-        d="M4 4.44v2.83c7.03 0 12.73 5.7 12.73 12.73h2.83c0-8.59-6.97-15.56-15.56-15.56zM4 10.1v2.83c3.9 0 7.07 3.17 7.07 7.07h2.83c0-5.47-4.43-9.9-9.9-9.9z"
-      />
+    <svg viewBox="0 0 24 24" width="20" height="20" aria-hidden="true" focusable="false" fill="currentColor">
+      <circle cx="6.18" cy="17.82" r="2.18" />
+      <path d="M4 4.44v2.83c7.03 0 12.73 5.7 12.73 12.73h2.83c0-8.59-6.97-15.56-15.56-15.56zM4 10.1v2.83c3.9 0 7.07 3.17 7.07 7.07h2.83c0-5.47-4.43-9.9-9.9-9.9z" />
     </svg>
   );
 }
@@ -152,14 +150,13 @@ export function Footer(): JSX.Element {
         </nav>
         {rssUrl && (
           <a
-            className={styles.feed}
+            className={styles.socialLink}
             href={rssUrl}
             aria-label={t("footer.rss")}
             title={t("footer.rss")}
             data-rss-feed=""
           >
             <RssIcon />
-            <span className={styles.feedLabel}>RSS</span>
           </a>
         )}
       </div>

--- a/src/components/chrome/Header.module.css
+++ b/src/components/chrome/Header.module.css
@@ -89,6 +89,38 @@
   background: #fff;
 }
 
+/* Language switcher: compact code links (EN / FR) beside the login control. The 2rem
+   min-height keeps each link a ≥24px tap target (target-size rule). */
+.langSelector {
+  display: flex;
+  align-items: center;
+  gap: 0.1rem;
+}
+.langLink {
+  display: inline-flex;
+  align-items: center;
+  min-height: 2rem;
+  padding: 0 0.5rem;
+  border-radius: var(--radius);
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: var(--color-text-muted);
+}
+.langLink:hover {
+  color: var(--color-accent);
+  background: var(--color-surface-2);
+  text-decoration: none;
+}
+.langLink:focus-visible {
+  outline: none;
+  box-shadow: var(--ring);
+}
+.langLink[aria-current="true"] {
+  color: var(--color-accent);
+  font-weight: 700;
+}
+
 @media (max-width: 720px) {
   .nav,
   .search {

--- a/src/components/chrome/Header.tsx
+++ b/src/components/chrome/Header.tsx
@@ -179,6 +179,8 @@ export function Header(): JSX.Element {
               signOut: t("chrome.login.signOut"),
               username: t("chrome.login.username"),
               password: t("chrome.login.password"),
+              invalidCredentials: t("chrome.login.invalidCredentials"),
+              accountLocked: t("chrome.login.accountLocked"),
             },
           }}
         />

--- a/src/components/chrome/Header.tsx
+++ b/src/components/chrome/Header.tsx
@@ -98,10 +98,15 @@ function siteLogoUrl(site: JCRNodeWrapper): string | null {
  */
 export function Header(): JSX.Element {
   const { t } = useTranslation();
-  const { renderContext, mainNode } = useServerContext();
+  const { renderContext, mainNode, currentResource } = useServerContext();
   const site = renderContext.getSite();
   const home = site.getHome();
   const siteTitle = site.getTitle();
+
+  // Language switcher: the site's configured languages (sorted for a stable order),
+  // each linking the current page/content in that language. Hidden for a single-language site.
+  const languages = Array.from(site.getLanguages(), String).sort();
+  const currentLang = currentResource.getLocale().getLanguage();
 
   const homeUrl = home ? buildNodeUrl(home) : buildNodeUrl(site);
   const logoUrl = siteLogoUrl(site);
@@ -165,6 +170,22 @@ export function Header(): JSX.Element {
             aria-label={t("chrome.search.label")}
           />
         </form>
+
+        {languages.length > 1 && (
+          <nav className={styles.langSelector} aria-label={t("chrome.language.label")}>
+            {languages.map((lang) => (
+              <a
+                key={lang}
+                className={styles.langLink}
+                href={buildNodeUrl(mainNode, { language: lang })}
+                hrefLang={lang}
+                aria-current={lang === currentLang ? "true" : undefined}
+              >
+                {lang.toUpperCase()}
+              </a>
+            ))}
+          </nav>
+        )}
 
         <Island
           component={Login}

--- a/src/components/chrome/Login.client.tsx
+++ b/src/components/chrome/Login.client.tsx
@@ -6,6 +6,10 @@ interface LoginLabels {
   signOut: string;
   username: string;
   password: string;
+  /** Shown when Jahia rejects the credentials (bad password / unknown user). */
+  invalidCredentials: string;
+  /** Shown when the account is locked. */
+  accountLocked: string;
 }
 
 interface LoginProps {
@@ -43,8 +47,28 @@ export default function Login({
   labels,
 }: Readonly<LoginProps>) {
   const [open, setOpen] = useState(false);
+  const [error, setError] = useState<string | null>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const usernameRef = useRef<HTMLInputElement>(null);
+
+  // After a failed login, Jahia's /cms/login servlet redirects back here with
+  // ?loginError=<reason> (bad_password / unknown_user / account_locked) instead of
+  // leaving the user on the bare /cms/login page. Surface it as an inline message and
+  // reopen the form, then strip the param so a refresh doesn't re-show the error.
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const reason = params.get("loginError");
+    if (!reason) return;
+    setError(reason === "account_locked" ? labels.accountLocked : labels.invalidCredentials);
+    setOpen(true);
+    params.delete("loginError");
+    const query = params.toString();
+    window.history.replaceState(
+      null,
+      "",
+      window.location.pathname + (query ? `?${query}` : "") + window.location.hash,
+    );
+  }, [labels.accountLocked, labels.invalidCredentials]);
 
   // On open, move focus into the panel (username field).
   useEffect(() => {
@@ -103,6 +127,13 @@ export default function Login({
         >
           {/* Where Jahia sends the browser after a successful login. */}
           <input type="hidden" name="redirect" value={loginRedirect} />
+          {/* On failure Jahia redirects here with ?loginError=<reason> (surfaced above). */}
+          <input type="hidden" name="failureRedirect" value={loginRedirect} />
+          {error && (
+            <p className={styles.error} role="alert">
+              {error}
+            </p>
+          )}
           <label htmlFor="login-username">{labels.username}</label>
           <input ref={usernameRef} id="login-username" name="username" autoComplete="username" required />
           <label htmlFor="login-password">{labels.password}</label>

--- a/src/components/chrome/Login.client.tsx
+++ b/src/components/chrome/Login.client.tsx
@@ -48,8 +48,15 @@ export default function Login({
 }: Readonly<LoginProps>) {
   const [open, setOpen] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [ready, setReady] = useState(false);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const usernameRef = useRef<HTMLInputElement>(null);
+
+  // Signal hydration: the sign-in trigger is server-rendered, so a click before the
+  // onClick is wired wouldn't open the panel. Tests wait for data-login-ready.
+  useEffect(() => {
+    setReady(true);
+  }, []);
 
   // After a failed login, Jahia's /cms/login servlet redirects back here with
   // ?loginError=<reason> (bad_password / unknown_user / account_locked) instead of
@@ -113,6 +120,7 @@ export default function Login({
         className={styles.loginBtn}
         aria-expanded={open}
         aria-controls="login-panel"
+        data-login-ready={ready ? "true" : undefined}
         onClick={() => setOpen((v) => !v)}
       >
         {labels.signIn}

--- a/src/components/chrome/login.module.css
+++ b/src/components/chrome/login.module.css
@@ -58,6 +58,17 @@
   font-weight: 600;
 }
 
+/* Inline credentials error (Jahia's ?loginError=… after a failed sign-in). */
+.error {
+  margin: 0 0 0.2rem;
+  padding: 0.5rem 0.65rem;
+  font-size: 0.82rem;
+  color: var(--color-danger);
+  background: #fdeaef; /* tint of --color-danger; text clears AAA on it */
+  border: 1px solid var(--color-danger);
+  border-radius: var(--radius);
+}
+
 .panel input[type="text"],
 .panel input[name="username"],
 .panel input[type="password"] {


### PR DESCRIPTION
## Summary

Follow-up to #10 — these commits were completed and E2E-verified on the migration branch but had not been pushed when #10 was merged.

- **fix: inline error on failed login** — the header login form now sends `failureRedirect` back to the current page; the Login island reads `?loginError=<reason>` (bad_password / unknown_user / account_locked), shows an inline `role=alert` message and reopens the panel instead of dumping the user on the bare `/cms/login` page.
- **fix: status facet matches case-insensitively** — migrated 4.3.0 data stores `status` capitalized (`Community`) while the facet submits the lowercase choicelist key, so the filter returned nothing; the JCR-SQL2 where-clause now compares `LOWER(e.[status])`.
- **fix: Login island hydration marker** — `data-login-ready` is set once React attaches handlers, so the SSR trigger can't be clicked into a dead button (same pattern as the versions dialog).
- **feat: brand icons for the footer social links** (Facebook / LinkedIn / X / YouTube, inline SVG, 36px square targets).
- **feat: RSS button styled like the social icons** and **grouped into a single "Follow us" nav**.
- **feat: header language selector** — SSR EN/FR links via `buildNodeUrl(mainNode, { language })`, `aria-current` on the active language, hidden when the site has a single language.

## Test plan

- [x] Built and deployed to a local Jahia 8.2.4 via the bundles API
- [x] `16-storefront.cy.ts` 14/14 (incl. new language-selector, status-case and inline-login-error tests)
- [x] `17-authoring.cy.ts` green (versions popup flows)
- [x] `20-accessibility.cy.ts` 3/3 — WCAG 2.2 AAA axe gate incl. the new selector and footer nav
- [x] Lint 0 errors / 0 warnings; SonarQube quality gate green

Companion test PR in privateappstore (same branch name).