### PR TITLE
SECURITY-571: remediate CodeQL alerts (double-escaping, xss-through-dom)

### DIFF
--- a/src/components/forge/IconUpload.tsx
+++ b/src/components/forge/IconUpload.tsx
@@ -186,7 +186,10 @@ export default function IconUpload({ path, workspace, iconUrl, labels }: Readonl
     }
   };
 
-  const shown = preview ?? iconUrl;
+  // The preview only ever displays a browser-minted `blob:` object-URL (created by
+  // URL.createObjectURL above); anything else falls back to the server-rendered icon.
+  // The scheme guard makes that invariant explicit (CodeQL js/xss-through-dom).
+  const shown = preview?.startsWith("blob:") ? preview : iconUrl;
 
   return (
     <div className={styles.icon} data-icon-status={status}>

--- a/src/components/forge/forgeCard.ts
+++ b/src/components/forge/forgeCard.ts
@@ -1,14 +1,18 @@
 import { buildNodeUrl, getChildNodes } from "@jahia/javascript-modules-library";
 import type { JCRNodeWrapper } from "org.jahia.services.content";
 
-/** Strip HTML tags + collapse whitespace from a Jahia richtext value. */
+/**
+ * Strip HTML tags + collapse whitespace from a Jahia richtext value.
+ * `&amp;` is unescaped LAST: doing it first turns `&amp;lt;` into `&lt;` and then
+ * into `<` — a double-unescape (CodeQL js/double-escaping).
+ */
 export function stripHtml(html: string): string {
   return (html || "")
     .replaceAll(/<[^>]*>/g, " ")
     .replaceAll("&nbsp;", " ")
-    .replaceAll("&amp;", "&")
     .replaceAll("&lt;", "<")
     .replaceAll("&gt;", ">")
+    .replaceAll("&amp;", "&")
     .replaceAll(/\s+/g, " ")
     .trim();
 }


### PR DESCRIPTION
Remediates the two open CodeQL code-scanning alerts on `master`. Companion to Jahia/privateappstore#30 (same remediation pass on the sibling repo).

## Changes

### `js/double-escaping` — alert #1 (`forgeCard.ts`)
**Real correctness bug**: `stripHtml` unescaped `&amp;` *before* `&lt;`/`&gt;`, so a double-escaped value like `&amp;lt;` was unescaped twice (→ `&lt;` → `<`). Reordered so `&amp;` is handled last — the canonical unescape order. Output is plain text rendered through React/SSR (escaped on render), so there was no XSS exposure; behavior changes only for double-escaped entities, which now unescape exactly one level.

### `js/xss-through-dom` — alert #2 (`IconUpload.tsx`)
The `<img src>` preview flows from the file input (a DOM source per CodeQL) through `URL.createObjectURL` into the `src` attribute. **Not exploitable** — `createObjectURL` always returns a browser-minted opaque `blob:` URL — but the invariant was implicit. Now explicit via a scheme guard: only a `blob:` preview is ever shown, anything else falls back to the server-rendered icon URL. Behavior unchanged.

## Test plan
- [x] `vite build` green, `dist/package.tgz` produced
- [x] Both changes provably behavior-preserving (`preview` is only ever set from `createObjectURL`; entity-order change affects only double-escaped input)
- [x] No E2E selector changes (`[data-icon-input]`/`[data-icon-status]` untouched)
- [ ] Repo CodeQL check on this PR validates both alerts are resolved