### PR TITLE
feat(storefront): sort the left-rail status & category facets alphabetically

### DIFF
--- a/src/components/ForgeModulesList/default.server.tsx
+++ b/src/components/ForgeModulesList/default.server.tsx
@@ -174,12 +174,15 @@ jahiaComponent(
             {term && <input type="hidden" name="src_terms" value={term} />}
             <fieldset className={filterStyles.facets}>
               <legend className={filterStyles.legend}>{labels.status}</legend>
-              {FORGE_STATUSES.map((s) => (
-                <label key={s} className={filterStyles.facet}>
-                  <input type="checkbox" name="status" value={s} defaultChecked={statuses.includes(s)} />
-                  <span className={filterStyles.facetStatus}>{s}</span>
-                </label>
-              ))}
+              {/* Alphabetical so the facet is easy to scan (the constant keeps lifecycle order). */}
+              {[...FORGE_STATUSES]
+                .sort((a, b) => a.localeCompare(b))
+                .map((s) => (
+                  <label key={s} className={filterStyles.facet}>
+                    <input type="checkbox" name="status" value={s} defaultChecked={statuses.includes(s)} />
+                    <span className={filterStyles.facetStatus}>{s}</span>
+                  </label>
+                ))}
             </fieldset>
             {categoryOptions.length > 0 && (
               <fieldset className={filterStyles.facets}>

--- a/src/components/forge/forgeFacets.ts
+++ b/src/components/forge/forgeFacets.ts
@@ -22,8 +22,9 @@ export interface ForgeCategoryOption {
 
 /**
  * The site's root-category children — the category facet options for the storefront
- * filter and the header advanced-search panel. Returns [] when no root category is
- * configured or it is unreadable. Kept here so both surfaces compute it identically.
+ * filter rail. Returns [] when no root category is configured or it is unreadable.
+ * Sorted alphabetically by (locale-aware) display name so the facet is easy to scan;
+ * `localeCompare` also satisfies the sort-with-comparator rule (S2871).
  */
 export function forgeCategoryOptions(
   siteKey: string,
@@ -40,5 +41,5 @@ export function forgeCategoryOptions(
   } catch {
     // root category missing / not readable — no category facet.
   }
-  return options;
+  return options.sort((a, b) => a.name.localeCompare(b.name));
 }


### PR DESCRIPTION
## Sort the storefront filter facets alphabetically

Small UX tweak to the left-rail filters on the modules list — both facet groups are now ordered alphabetically so they're easier to scan/select. Companion test PR: **Jahia/privateappstore#34**.

- **Status** — rendered alphabetically (`community, labs, legacy, supported`). Sorted at the render site; the `FORGE_STATUSES` constant keeps its lifecycle order for any semantic use.
- **Categories** — `forgeCategoryOptions` returns the options sorted by **locale-aware display name** (`localeCompare`, which also satisfies Sonar `S2871`), so they list A→Z and stay correct per language (en/fr titles).

### Test plan
- [x] `npm run build` green
- [x] Cypress `16-storefront` **22/22** (incl. a new alphabetical-status-order assertion), `20-accessibility` (WCAG 2.2 AAA) **3/3**
