### PR TITLE
fix(security): validate author-supplied values before URL, iframe and upload sinks

### DIFF
--- a/src/components/Videostreaming/default.server.tsx
+++ b/src/components/Videostreaming/default.server.tsx
@@ -3,6 +3,13 @@ import { str } from "~/components/forge/nodeProps";
 import styles from "~/components/forge/video.module.css";
 
 /**
+ * YouTube / Vimeo video ids are plain tokens (YouTube: 11 url-safe chars, Vimeo: digits).
+ * The identifier is author-supplied, so anything else (slashes, dots, query chars) is
+ * rejected rather than letting an author steer the iframe to another path on the provider.
+ */
+const SAFE_VIDEO_ID = /^[A-Za-z0-9_-]+$/;
+
+/**
  * Video embed for a jnt:videostreaming node (YouTube / Vimeo), from its
  * `provider` + `identifier` properties. Replaces the legacy lity-based view.
  */
@@ -13,8 +20,9 @@ jahiaComponent(
     const id = str(currentNode, "identifier");
 
     let src: string | null = null;
-    if (provider === "youtube" && id) src = `https://www.youtube.com/embed/${id}`;
-    else if (provider === "vimeo" && id) src = `https://player.vimeo.com/video/${id}`;
+    if (!id || !SAFE_VIDEO_ID.test(id)) src = null;
+    else if (provider === "youtube") src = `https://www.youtube.com/embed/${id}`;
+    else if (provider === "vimeo") src = `https://player.vimeo.com/video/${id}`;
 
     if (!src) return <></>;
 

--- a/src/components/forge/IconUpload.tsx
+++ b/src/components/forge/IconUpload.tsx
@@ -30,6 +30,11 @@ interface IconUploadProps {
     is sent as a GraphQL multipart request part via gqlUpload, not a base64 JSON value). */
 const MAX_BYTES = 2 * 1024 * 1024;
 
+/** Raster image types only. SVG is deliberately excluded: image/svg+xml can carry
+    scripts when served inline, and the stored jcr:mimeType drives how Jahia serves
+    the file back. The same list feeds the input's `accept` attribute. */
+const ALLOWED_ICON_TYPES = ["image/png", "image/jpeg", "image/gif", "image/webp"] as const;
+
 type Status = "idle" | "uploading" | "uploaded" | "error";
 
 /** `ws` is a server-computed enum ("EDIT" | "LIVE"), never user input - safe to interpolate. */
@@ -133,7 +138,7 @@ export default function IconUpload({ path, workspace, iconUrl, labels }: Readonl
       setFile(null);
       return;
     }
-    if (!next.type.startsWith("image/")) {
+    if (!(ALLOWED_ICON_TYPES as readonly string[]).includes(next.type)) {
       setStatus("error");
       setMessage(labels.invalidType);
       return;
@@ -208,7 +213,7 @@ export default function IconUpload({ path, workspace, iconUrl, labels }: Readonl
           <input
             ref={inputRef}
             type="file"
-            accept="image/*"
+            accept={ALLOWED_ICON_TYPES.join(",")}
             data-icon-input=""
             aria-label={labels.choose}
             onChange={(e) => pick(e.target.files?.[0] ?? null)}

--- a/src/components/forge/versions.ts
+++ b/src/components/forge/versions.ts
@@ -18,12 +18,20 @@ export function compareVersionsDesc(a: string, b: string): number {
 }
 
 /**
+ * One path segment of a MavenProxy URL: Maven-coordinate charset only, and never a bare
+ * "." / ".." that the browser would normalize into a traversal out of /modules/mavenproxy/.
+ * groupId/versionNumber are author-supplied module properties, so they can't be trusted.
+ */
+const SAFE_MAVEN_SEGMENT = /^(?!\.{1,2}$)[A-Za-z0-9._-]+$/;
+
+/**
  * Download URL for a version. If a jnt:file is attached (JS modules / packages),
  * link to that genuine artifact. Otherwise (JAR modules deployed to the site's
  * Maven repo) build the MavenProxy URL from the module coordinates instead of a
  * stored absolute URL - a root-relative `/modules/mavenproxy/…` so the browser
  * resolves it against whatever scheme/host/port the storefront is served on.
- * Mirrors the catalog moduleList.jsp generation.
+ * Mirrors the catalog moduleList.jsp generation. Returns null when any
+ * coordinate fails validation rather than emitting a traversable href.
  */
 export function versionDownloadUrl(version: JCRNodeWrapper): string | null {
   const files = getChildNodes(version, 1, 0, (n) => n.isNodeType("jnt:file"));
@@ -37,7 +45,10 @@ export function versionDownloadUrl(version: JCRNodeWrapper): string | null {
   if (!groupId || !versionNumber) return null;
   const site = module.getResolveSite().getSiteKey();
   const name = module.getName();
-  const groupPath = groupId.replaceAll(".", "/");
+  const groupSegments = groupId.split(".");
+  const segments = [site, ...groupSegments, name, versionNumber];
+  if (!segments.every((segment) => SAFE_MAVEN_SEGMENT.test(segment))) return null;
+  const groupPath = groupSegments.join("/");
   return `/modules/mavenproxy/${site}/${groupPath}/${name}/${versionNumber}/${name}-${versionNumber}.jar`;
 }
 


### PR DESCRIPTION
## Summary

Security-hardening pass on `jahia-store-template`, driven by a fresh audit. Validates author-supplied (semi-trusted) values before they reach URL, iframe, and upload sinks. Build green; verified by the companion repo's **full Cypress E2E 102/102**.

## Changes (`cf1585d`)

- **`versions.ts versionDownloadUrl`**: validate every MavenProxy URL segment (site, groupId parts, name, versionNumber) against the Maven charset, rejecting bare `.`/`..`. An author-supplied `groupId` like `"...."` produced `..` path segments the browser normalizes — turning the Download href into an arbitrary same-origin path. Now returns `null` instead of emitting a traversable href.
- **`Videostreaming/default.server.tsx`**: pin the YouTube/Vimeo `identifier` to `[A-Za-z0-9_-]+` so an author can't smuggle path/query into the embed iframe `src` (e.g. swap a video for an arbitrary playlist).
- **`IconUpload.tsx`**: replace the broad `image/*` check with a raster-only MIME allowlist (png/jpeg/gif/webp) on both the validation and the input's `accept` — `image/svg+xml` can carry scripts when served inline.

## Test plan

- [x] `npm run build` / `mvn package` green (type-check + bundle)
- [x] Full Cypress E2E suite (companion repo, modules deployed): **102/102 passing, 0 failures** — storefront, authoring, richtext, accessibility, upload/download all green

Companion PR: privateappstore security hardening (same branch name).


---
Companion PR: https://github.com/Jahia/privateappstore/pull/35
