### PR TITLE
feat(ui): Nunito Sans font + Moonstone gray_dark body text

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "5.0.0-SNAPSHOT",
       "license": "Apache-2.0",
       "dependencies": {
+        "@fontsource-variable/nunito-sans": "^5.2.7",
         "clsx": "^2.1.1",
         "dompurify": "^3.4.7",
         "i18next": "^25.8.18",
@@ -34,6 +35,14 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@fontsource-variable/nunito-sans": {
+      "version": "5.2.7",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/nunito-sans/-/nunito-sans-5.2.7.tgz",
+      "integrity": "sha512-rflH5HeAoNjIkwftStzQvxqCJhIS+usMr/lfslWg/RCa499B5qxyjo+74R/QMM0geQt4AY1URlG7wAR1iq6KPQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@jahia/javascript-modules-library": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "deploy": "jahia-deploy"
   },
   "dependencies": {
+    "@fontsource-variable/nunito-sans": "^5.2.7",
     "clsx": "^2.1.1",
     "dompurify": "^3.4.7",
     "i18next": "^25.8.18",

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -19,8 +19,10 @@
   --color-danger: #a00f33; /* AAA: ≈8.1:1 on white (and white-on-danger ≈8.0:1) */
   --color-danger-hover: #850c2a;
 
-  --font-sans: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial,
-    sans-serif;
+  /* Nunito Sans (self-hosted variable font, imported in Layout.tsx); the system
+     stack is the font-display:swap fallback shown until the woff2 loads. */
+  --font-sans: "Nunito Sans Variable", ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto,
+    Helvetica, Arial, sans-serif;
 
   --radius: 8px;
   --radius-lg: 12px;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -6,10 +6,18 @@
    text-on-white (links) and as a button fill (white-on-accent), so the
    automated AAA contrast gate (axe color-contrast-enhanced) stays green. */
 :root {
+  /* Moonstone design tokens. Values copied from @jahia/moonstone
+     (https://jahia.github.io/moonstone/?path=/docs/tokens-colors--docs); the
+     library itself is never bundled into this SSR module (see CLAUDE.md), so the
+     few tokens we reuse are hardcoded here. Only AAA-safe tokens are adopted:
+     Moonstone's base accent (#00a0e3 ≈2.5:1) and gray (#7a7f88 ≈3.6:1) fail the
+     AAA contrast gate (spec 20), so the accent/muted tokens below stay tuned. */
+  --moon-color-gray_dark: #293136; /* body text - AAA ≈13:1 on white */
+
   --color-bg: #ffffff;
   --color-surface: #f7f9fc;
   --color-surface-2: #eef2f8;
-  --color-text: #1a2233;
+  --color-text: var(--moon-color-gray_dark);
   --color-text-muted: #45506a; /* AAA: ≈7.9:1 on white */
   --color-border: #d9e0ea;
   --color-accent: #0e4ea8; /* Jahia blue - AAA both ways */

--- a/src/templates/Layout.tsx
+++ b/src/templates/Layout.tsx
@@ -1,6 +1,12 @@
 import type { ReactNode } from "react";
 import { AddResources, buildModuleFileUrl, useServerContext } from "@jahia/javascript-modules-library";
 import { useTranslation } from "react-i18next";
+// Self-hosted Nunito Sans (variable, weight axis 200-1000, normal). Bundled into
+// the module's single style.css; Vite emits the per-subset woff2 into dist/assets
+// (served via the module's static-resources). font-display:swap + unicode-range
+// mean only the subset a page needs is fetched. The family is wired into
+// --font-sans in global.css; the system stack stays as the swap fallback.
+import "@fontsource-variable/nunito-sans/wght.css";
 import "~/styles/global.css";
 import styles from "./Layout.module.css";
 import { Header } from "~/components/chrome/Header";


### PR DESCRIPTION
## Summary

Restyle the storefront UI: adopt the **Nunito Sans** variable font and use the Moonstone **`gray_dark`** token for body text. Build green; **full Cypress E2E 102/102** (incl. the `20-accessibility` WCAG AAA contrast gate).

## Changes

**`6a7af44` — Nunito Sans variable font (self-hosted)**
- Add `@fontsource-variable/nunito-sans` (v5.2.7) and import its `wght` CSS in `Layout.tsx`, so Vite bundles the `@font-face` into the module's single `dist/assets/style.css` and emits the per-subset `.woff2` into `dist/assets` (served via `static-resources`; `url()` refs are relative to `style.css`).
- `--font-sans` now leads with `"Nunito Sans Variable"`, keeping the system stack as the `font-display: swap` fallback.
- Self-hosted (no CDN request) — keeps a strict/nonce CSP viable. `unicode-range` per subset means a page fetches only what it needs (~30 KB latin for EN/FR). Italic axis intentionally omitted to stay lean.

**`fd229a0` — Moonstone `gray_dark` body text**
- Body text → `--moon-color-gray_dark` (`#293136`, ≈13:1 on white), introduced as a hardcoded CSS var (Moonstone is never bundled into the SSR module, per repo rules).
- **Only** the text color changed. `bg`/`surface`/`muted`/`border`/`accent`/`navy`/`danger` are untouched: Moonstone's base `accent` (#00a0e3 ≈2.5:1) and `gray` (#7a7f88 ≈3.6:1) fail the AAA contrast gate, so the existing AAA-tuned tokens are kept.

## Test plan

- [x] `npm run build` / `mvn package` green
- [x] woff2 emitted to `dist/assets` and shipped in `package.tgz`; `style.css` carries the `@font-face` + the `--moon-color-gray_dark` token
- [x] Full Cypress E2E: **102/102 passing, 0 failures** across all 20 specs, including `20-accessibility` (AAA contrast) — verified for the font-only and the combined font+color builds
