### PR TITLE
refactor(detail): decompose ForgeEntryDetail (sidebar + versions dialog)

### DIFF
--- a/src/components/forge/DetailInfoRail.tsx
+++ b/src/components/forge/DetailInfoRail.tsx
@@ -1,0 +1,124 @@
+import { useTranslation } from "react-i18next";
+import styles from "./detail.module.css";
+
+/** Only http(s) URLs are safe to render as a link href (blocks stored javascript:/data: URLs). */
+function isHttpUrl(url: string): boolean {
+  return /^https?:\/\//i.test(url.trim());
+}
+
+interface DetailInfoRailProps {
+  moduleId: string;
+  groupId: string;
+  status: string;
+  categoryNames: string[];
+  author: string;
+  authorURL: string;
+  requiresJahia: string;
+  updated: string;
+  codeRepository: string;
+  tags: string[];
+}
+
+/**
+ * The persistent "Information" rail on the module detail page — always visible (not
+ * behind a tab), as in the legacy UI. A `<div>`, not `<aside>`: a complementary
+ * landmark nested in `<main>` trips the axe AAA gate. DOM order is main-first
+ * (reading order); CSS grid places this rail on the left.
+ */
+export function DetailInfoRail({
+  moduleId,
+  groupId,
+  status,
+  categoryNames,
+  author,
+  authorURL,
+  requiresJahia,
+  updated,
+  codeRepository,
+  tags,
+}: Readonly<DetailInfoRailProps>): JSX.Element {
+  const { t } = useTranslation();
+  return (
+    <div className={styles.sidebar} data-detail-info="">
+      <h2 className={styles.sidebarTitle}>{t("detail.tabs.information")}</h2>
+      <dl className={styles.meta}>
+        <dt>{t("detail.meta.moduleId")}</dt>
+        <dd>{moduleId}</dd>
+        {groupId && (
+          <>
+            <dt>{t("detail.meta.groupId")}</dt>
+            <dd>{groupId}</dd>
+          </>
+        )}
+        {status && (
+          <>
+            <dt>{t("detail.meta.status")}</dt>
+            <dd className={styles.metaStatus}>{status}</dd>
+          </>
+        )}
+        {categoryNames.length > 0 && (
+          <>
+            <dt>{t("detail.meta.category")}</dt>
+            <dd>{categoryNames.join(", ")}</dd>
+          </>
+        )}
+        {author && (
+          <>
+            <dt>{t("detail.meta.author")}</dt>
+            <dd>{author}</dd>
+          </>
+        )}
+        {isHttpUrl(authorURL) && (
+          <>
+            <dt>{t("detail.meta.developerWebsite")}</dt>
+            <dd>
+              <a href={authorURL} rel="noopener noreferrer nofollow" target="_blank">
+                {authorURL}
+              </a>
+            </dd>
+          </>
+        )}
+        {requiresJahia && (
+          <>
+            <dt>{t("detail.meta.requiresJahia")}</dt>
+            <dd>{requiresJahia}</dd>
+          </>
+        )}
+        {updated && (
+          <>
+            <dt>{t("detail.meta.updated")}</dt>
+            <dd>{updated}</dd>
+          </>
+        )}
+        {codeRepository && (
+          <>
+            <dt>{t("detail.meta.source")}</dt>
+            <dd>
+              {isHttpUrl(codeRepository) ? (
+                <a href={codeRepository} rel="noopener noreferrer nofollow" target="_blank">
+                  {codeRepository}
+                </a>
+              ) : (
+                codeRepository
+              )}
+            </dd>
+          </>
+        )}
+        {tags.length > 0 && (
+          <>
+            <dt>{t("detail.meta.tags")}</dt>
+            <dd>
+              <ul className={styles.tagList} data-tag-list="">
+                {tags.map((tag) => (
+                  <li key={tag} className={styles.tag}>
+                    {tag}
+                  </li>
+                ))}
+              </ul>
+            </dd>
+          </>
+        )}
+      </dl>
+    </div>
+  );
+}

--- a/src/components/forge/DetailVersionsDialog.tsx
+++ b/src/components/forge/DetailVersionsDialog.tsx
@@ -1,0 +1,83 @@
+import { Island, Render } from "@jahia/javascript-modules-library";
+import type { JCRNodeWrapper } from "org.jahia.services.content";
+import { useTranslation } from "react-i18next";
+import styles from "./detail.module.css";
+import FileUploadForm from "~/components/FileUpload/FileUpload.client";
+
+interface DetailVersionsDialogProps {
+  versions: JCRNodeWrapper[];
+  /** The createEntryFromJar action URL for the owner upload form, or null for non-owners. */
+  uploadActionUrl: string | null;
+  /** Where the upload form returns to after a successful post (the module page). */
+  backUrl: string;
+}
+
+/**
+ * Versions popup, opened by the header "Versions" button (VersionsDialog island). A native
+ * `<dialog>` gives a focus trap, Escape-to-close and an inert backdrop for free; its content
+ * (Jahia version views + the owner-only upload-new-version form) is server-rendered.
+ */
+export function DetailVersionsDialog({
+  versions,
+  uploadActionUrl,
+  backUrl,
+}: Readonly<DetailVersionsDialogProps>): JSX.Element {
+  const { t } = useTranslation();
+
+  // Labels for the owner-only "upload a new version" form. Posts to the same
+  // createEntryFromJar action as the my-modules upload — the action upserts (matches
+  // the module by groupId+name in the package) and appends the version.
+  const ADD_VERSION_LABELS = {
+    fileLabel: t("addVersion.fileLabel"),
+    submit: t("addVersion.submit"),
+    submitting: t("addVersion.submitting"),
+    pickFile: t("addVersion.pickFile"),
+    error: t("addVersion.error"),
+  };
+
+  return (
+    <dialog
+      className={styles.versionsDialog}
+      data-versions-dialog=""
+      aria-modal="true"
+      aria-labelledby="versions-dialog-title"
+    >
+      <div className={styles.dialogHead}>
+        <h2 id="versions-dialog-title" className={styles.dialogTitle}>
+          {t("detail.tabs.versions")}
+        </h2>
+        <form method="dialog">
+          <button type="submit" className={styles.dialogClose} aria-label={t("detail.versions.close")}>
+            <span aria-hidden="true">×</span>
+          </button>
+        </form>
+      </div>
+      <div className={styles.dialogBody}>
+        {versions.length === 0 ? (
+          <p className={styles.muted}>{t("detail.versions.none")}</p>
+        ) : (
+          <div className={styles.versions}>
+            {versions.map((v) => (
+              <Render key={v.getIdentifier()} node={v} view="default" readOnly />
+            ))}
+          </div>
+        )}
+        {uploadActionUrl && (
+          <section className={styles.section} data-add-version="">
+            <h3 className={styles.sectionTitle}>{t("detail.versions.uploadTitle")}</h3>
+            <p className={styles.muted}>{t("detail.versions.uploadHelp")}</p>
+            <Island
+              component={FileUploadForm}
+              props={{
+                actionUrl: uploadActionUrl,
+                backUrl,
+                accept: ".jar",
+                labels: ADD_VERSION_LABELS,
+              }}
+            />
+          </section>
+        )}
+      </div>
+    </dialog>
+  );
+}

--- a/src/components/forge/ForgeEntryDetail.tsx
+++ b/src/components/forge/ForgeEntryDetail.tsx
@@ -20,7 +20,8 @@ import ModuleEditor from "./ModuleEditor.client";
 import PublishToggle from "./PublishToggle.client";
 import DetailTabs from "./DetailTabs.client";
 import VersionsDialog from "./VersionsDialog.client";
-import FileUploadForm from "~/components/FileUpload/FileUpload.client";
+import { DetailInfoRail } from "./DetailInfoRail";
+import { DetailVersionsDialog } from "./DetailVersionsDialog";
 
 interface TabDef {
   id: string;
@@ -56,11 +57,6 @@ function screenshotItems(node: JCRNodeWrapper): { name: string; url: string }[] 
   );
 }
 
-/** Only http(s) URLs are safe to render as a link href (blocks stored javascript:/data: URLs). */
-function isHttpUrl(url: string): boolean {
-  return /^https?:\/\//i.test(url.trim());
-}
-
 /**
  * Detail of a forge module/package: header, description, video, screenshots
  * (lightbox), versions (rendered via their `default` view), metadata and an
@@ -91,18 +87,6 @@ export function ForgeEntryDetail({ node }: Readonly<{ node: JCRNodeWrapper }>): 
   };
 
   const EDITOR_LABELS = buildEditorLabels(t);
-
-  // Labels for the owner-only "upload a new version" form on the detail page. Posts
-  // to the same createEntryFromJar action as the my-modules upload - the action
-  // upserts (matches the module by groupId+name in the package) and appends the
-  // version - so the only thing missing was an entry point on the module's own page.
-  const ADD_VERSION_LABELS = {
-    fileLabel: t("addVersion.fileLabel"),
-    submit: t("addVersion.submit"),
-    submitting: t("addVersion.submitting"),
-    pickFile: t("addVersion.pickFile"),
-    error: t("addVersion.error"),
-  };
 
   const title = str(node, "jcr:title") || node.getName();
   // Richtext fields are sanitized server-side before they reach the DOM (covers
@@ -252,90 +236,18 @@ export function ForgeEntryDetail({ node }: Readonly<{ node: JCRNodeWrapper }>): 
       )}
 
       <div className={styles.body}>
-        {/* Persistent "Information" rail — always visible (not behind a tab) as in the old UI.
-            A <div>, not <aside>: a complementary landmark nested in <main> trips the axe AAA gate.
-            DOM order is main-first (reading order); CSS grid places this rail on the left. */}
-        <div className={styles.sidebar} data-detail-info="">
-          <h2 className={styles.sidebarTitle}>{t("detail.tabs.information")}</h2>
-          <dl className={styles.meta}>
-            <dt>{t("detail.meta.moduleId")}</dt>
-            <dd>{moduleId}</dd>
-            {groupId && (
-              <>
-                <dt>{t("detail.meta.groupId")}</dt>
-                <dd>{groupId}</dd>
-              </>
-            )}
-            {status && (
-              <>
-                <dt>{t("detail.meta.status")}</dt>
-                <dd className={styles.metaStatus}>{status}</dd>
-              </>
-            )}
-            {categoryNames.length > 0 && (
-              <>
-                <dt>{t("detail.meta.category")}</dt>
-                <dd>{categoryNames.join(", ")}</dd>
-              </>
-            )}
-            {author && (
-              <>
-                <dt>{t("detail.meta.author")}</dt>
-                <dd>{author}</dd>
-              </>
-            )}
-            {isHttpUrl(authorURL) && (
-              <>
-                <dt>{t("detail.meta.developerWebsite")}</dt>
-                <dd>
-                  <a href={authorURL} rel="noopener noreferrer nofollow" target="_blank">
-                    {authorURL}
-                  </a>
-                </dd>
-              </>
-            )}
-            {requiresJahia && (
-              <>
-                <dt>{t("detail.meta.requiresJahia")}</dt>
-                <dd>{requiresJahia}</dd>
-              </>
-            )}
-            {updated && (
-              <>
-                <dt>{t("detail.meta.updated")}</dt>
-                <dd>{updated}</dd>
-              </>
-            )}
-            {codeRepository && (
-              <>
-                <dt>{t("detail.meta.source")}</dt>
-                <dd>
-                  {isHttpUrl(codeRepository) ? (
-                    <a href={codeRepository} rel="noopener noreferrer nofollow" target="_blank">
-                      {codeRepository}
-                    </a>
-                  ) : (
-                    codeRepository
-                  )}
-                </dd>
-              </>
-            )}
-            {tags.length > 0 && (
-              <>
-                <dt>{t("detail.meta.tags")}</dt>
-                <dd>
-                  <ul className={styles.tagList} data-tag-list="">
-                    {tags.map((tag) => (
-                      <li key={tag} className={styles.tag}>
-                        {tag}
-                      </li>
-                    ))}
-                  </ul>
-                </dd>
-              </>
-            )}
-          </dl>
-        </div>
+        <DetailInfoRail
+          moduleId={moduleId}
+          groupId={groupId}
+          status={status}
+          categoryNames={categoryNames}
+          author={author}
+          authorURL={authorURL}
+          requiresJahia={requiresJahia}
+          updated={updated}
+          codeRepository={codeRepository}
+          tags={tags}
+        />
 
         <div className={styles.main}>
           {tabs.length > 0 && (
@@ -399,52 +311,11 @@ export function ForgeEntryDetail({ node }: Readonly<{ node: JCRNodeWrapper }>): 
         </div>
       </div>
 
-      {/* Versions popup, opened by the header "Versions" button (VersionsDialog island). A native
-          <dialog> gives a focus trap, Escape-to-close and an inert backdrop for free; its content
-          (Jahia version views + the owner upload form) is server-rendered. */}
-      <dialog
-        className={styles.versionsDialog}
-        data-versions-dialog=""
-        aria-modal="true"
-        aria-labelledby="versions-dialog-title"
-      >
-        <div className={styles.dialogHead}>
-          <h2 id="versions-dialog-title" className={styles.dialogTitle}>
-            {t("detail.tabs.versions")}
-          </h2>
-          <form method="dialog">
-            <button type="submit" className={styles.dialogClose} aria-label={t("detail.versions.close")}>
-              <span aria-hidden="true">×</span>
-            </button>
-          </form>
-        </div>
-        <div className={styles.dialogBody}>
-          {versions.length === 0 ? (
-            <p className={styles.muted}>{t("detail.versions.none")}</p>
-          ) : (
-            <div className={styles.versions}>
-              {versions.map((v) => (
-                <Render key={v.getIdentifier()} node={v} view="default" readOnly />
-              ))}
-            </div>
-          )}
-          {uploadActionUrl && (
-            <section className={styles.section} data-add-version="">
-              <h3 className={styles.sectionTitle}>{t("detail.versions.uploadTitle")}</h3>
-              <p className={styles.muted}>{t("detail.versions.uploadHelp")}</p>
-              <Island
-                component={FileUploadForm}
-                props={{
-                  actionUrl: uploadActionUrl,
-                  backUrl: buildNodeUrl(node),
-                  accept: ".jar",
-                  labels: ADD_VERSION_LABELS,
-                }}
-              />
-            </section>
-          )}
-        </div>
-      </dialog>
+      <DetailVersionsDialog
+        versions={versions}
+        uploadActionUrl={uploadActionUrl}
+        backUrl={buildNodeUrl(node)}
+      />
     </article>
   );
 }


### PR DESCRIPTION
## What

Second deferred blind-review item: decompose the 450-line `ForgeEntryDetail` by extracting its two largest self-contained server regions (the ones the review named).

- **`DetailInfoRail`** — the persistent "Information" rail (the metadata `<dl>`), carrying the `isHttpUrl` link guard that only it uses. Takes the resolved metadata primitives as props.
- **`DetailVersionsDialog`** — the native `<dialog>` versions popup (Jahia version views + the owner-only upload-new-version form), building its own `ADD_VERSION_LABELS`.

`ForgeEntryDetail` (**450 → 321 lines**) now composes them.

## No behaviour change
Every E2E data hook is preserved (`data-detail-info`, `data-tag-list`, `data-versions-dialog`, `data-add-version`), and the two-tablist structure + AAA landmark layout (the rail stays a `<div>`, not `<aside>`) are unchanged.

## Verification (against the redeployed module)
- `12-moduleTabs` + `17-authoring` + `18-prepackaged`: **32/32**
- `20-accessibility`: **5/5** (module detail page + editor + lightbox, WCAG 2.2 AAA)
- `16-storefront`: **22/22** (incl. the Information rail + detail page)

## Test plan
- [x] Detail/tabs/authoring/prepackaged green
- [x] Accessibility AAA green (detail + editor + lightbox)
- [x] Storefront green
- [ ] CI green