### PR TITLE
SECURITY-571: storefront search + editor UX polish

### DIFF
--- a/settings/locales/en.json
+++ b/settings/locales/en.json
@@ -186,6 +186,8 @@
       "status": "Status",
       "category": "Category",
       "noCategories": "No categories are configured for this store yet.",
+      "categoryAdd": "Add a category…",
+      "categoryRemove": "Remove category",
       "tags": "Tags",
       "tag": {
         "add": "Add tag",

--- a/settings/locales/fr.json
+++ b/settings/locales/fr.json
@@ -186,6 +186,8 @@
       "status": "Statut",
       "category": "Catégorie",
       "noCategories": "Aucune catégorie n'est encore configurée pour ce store.",
+      "categoryAdd": "Ajouter une catégorie…",
+      "categoryRemove": "Supprimer la catégorie",
       "tags": "Étiquettes",
       "tag": {
         "add": "Ajouter une étiquette",

--- a/src/components/chrome/AdvancedSearchSync.client.tsx
+++ b/src/components/chrome/AdvancedSearchSync.client.tsx
@@ -30,8 +30,8 @@ export default function AdvancedSearchSync() {
     // that does NOT vary by query string, so these must be injected client-side from the live URL
     // rather than server-rendered (SSR values would freeze and leak the first visitor's filters).
     const form = markerRef.current?.closest<HTMLFormElement>("[role='search']");
+    const termInput = form?.querySelector<HTMLInputElement>("input[name='src_terms']") ?? null;
     if (form) {
-      const termInput = form.querySelector<HTMLInputElement>("input[name='src_terms']");
       if (termInput) termInput.value = params.get("src_terms") ?? "";
 
       for (const name of ["status", "category"]) {
@@ -44,6 +44,27 @@ export default function AdvancedSearchSync() {
         }
       }
     }
+
+    // 1b. Clearing the search re-applies. The native `type=search` "×" button empties the field
+    // but does NOT submit, so the listing would keep showing the old keyword filter until the user
+    // pressed Enter. The `search` event fires on that clear gesture (and on Enter); when it leaves
+    // the field empty we submit the header form — which now carries the active facets as hidden
+    // inputs — so the keyword is dropped immediately while the status/category selection is kept.
+    // Gate on a non-empty `src_terms` in the URL: that scopes us to a genuine clear of an active
+    // search, and stops an already-empty field from double-submitting alongside the browser's own
+    // Enter submit. A non-empty value (Enter on a typed term) is left to that native submit.
+    const onSearch = () => {
+      if (
+        form &&
+        termInput &&
+        !termInput.value.trim() &&
+        (params.get("src_terms") ?? "").trim()
+      ) {
+        if (typeof form.requestSubmit === "function") form.requestSubmit();
+        else form.submit();
+      }
+    };
+    termInput?.addEventListener("search", onSearch);
 
     // 2. Language switcher: carry the current filter/search query onto each link so
     // switching language preserves it. Drop `page` — the other-language catalogue may
@@ -91,6 +112,7 @@ export default function AdvancedSearchSync() {
     document.addEventListener("pointerdown", onPointerDown);
     globalThis.addEventListener("pageshow", onPageShow);
     return () => {
+      termInput?.removeEventListener("search", onSearch);
       document.removeEventListener("keydown", onKeyDown);
       document.removeEventListener("pointerdown", onPointerDown);
       globalThis.removeEventListener("pageshow", onPageShow);

--- a/src/components/chrome/nav-progress.module.css
+++ b/src/components/chrome/nav-progress.module.css
@@ -28,7 +28,7 @@
     var(--color-accent-hover, var(--color-accent))
   );
   transform: translateX(-100%);
-  animation: navProgressSlide 1.05s cubic-bezier(0.4, 0, 0.2, 1) infinite;
+  animation: navProgressSlide 1.9s cubic-bezier(0.4, 0, 0.2, 1) infinite;
   will-change: transform;
 }
 @keyframes navProgressSlide {

--- a/src/components/forge/CategorySelect.tsx
+++ b/src/components/forge/CategorySelect.tsx
@@ -1,0 +1,88 @@
+import type { ChangeEvent } from "react";
+import styles from "./editor.module.css";
+
+export interface CategoryOption {
+  uuid: string;
+  name: string;
+}
+
+export interface CategorySelectLabels {
+  /** Placeholder option for the "add" dropdown. */
+  placeholder: string;
+  /** Prefix for a chip's remove-button accessible name. */
+  remove: string;
+}
+
+interface CategorySelectProps {
+  id: string;
+  options: CategoryOption[];
+  selected: string[];
+  ariaLabel: string;
+  labels: CategorySelectLabels;
+  onToggle: (uuid: string) => void;
+}
+
+/**
+ * Category picker styled like the tag editor (chips), but constrained to the store's
+ * fixed category tree rather than free text: the selected categories show as removable
+ * chips and a dropdown adds from the not-yet-selected options. A category is either
+ * selected or not, so the single `onToggle` serves both add (pick an option) and remove
+ * (chip ×). The add `<select>` is controlled at `value=""` so it always rests on the
+ * placeholder; picking an option fires onToggle and the list re-renders without it.
+ */
+export default function CategorySelect({
+  id,
+  options,
+  selected,
+  ariaLabel,
+  labels,
+  onToggle,
+}: Readonly<CategorySelectProps>) {
+  const nameOf = new Map(options.map((o) => [o.uuid, o.name]));
+  const available = options.filter((o) => !selected.includes(o.uuid));
+
+  const onPick = (e: ChangeEvent<HTMLSelectElement>) => {
+    if (e.target.value) onToggle(e.target.value);
+  };
+
+  return (
+    <div className={styles.tagInput} data-category-select="">
+      <ul className={styles.tagChips}>
+        {selected.map((uuid) => {
+          const name = nameOf.get(uuid) ?? uuid;
+          return (
+            <li key={uuid} className={styles.tagChip}>
+              <span>{name}</span>
+              <button
+                type="button"
+                className={styles.tagRemove}
+                aria-label={`${labels.remove}: ${name}`}
+                onClick={() => onToggle(uuid)}
+              >
+                ×
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+      {available.length > 0 && (
+        <select
+          id={id}
+          className={styles.tagPicker}
+          aria-label={ariaLabel}
+          value=""
+          onChange={onPick}
+        >
+          <option value="" disabled>
+            {labels.placeholder}
+          </option>
+          {available.map((o) => (
+            <option key={o.uuid} value={o.uuid}>
+              {o.name}
+            </option>
+          ))}
+        </select>
+      )}
+    </div>
+  );
+}

--- a/src/components/forge/MetadataFields.tsx
+++ b/src/components/forge/MetadataFields.tsx
@@ -1,15 +1,17 @@
 import styles from "./editor.module.css";
 import TagInput, { type TagInputLabels } from "./TagInput";
+import CategorySelect, { type CategoryOption } from "./CategorySelect";
 
-export interface CategoryOption {
-  uuid: string;
-  name: string;
-}
+export type { CategoryOption };
 
 export interface MetadataLabels {
   status: string;
   category: string;
   noCategories: string;
+  /** Placeholder for the category "add" dropdown. */
+  categoryAdd: string;
+  /** Prefix for a category chip's remove-button accessible name. */
+  categoryRemove: string;
   tags: string;
   tag: TagInputLabels;
 }
@@ -66,23 +68,20 @@ export default function MetadataFields({
       </div>
 
       <div className={styles.field}>
-        <span className={styles.fieldLabel}>{labels.category}</span>
+        <label className={styles.fieldLabel} htmlFor="edit-category">
+          {labels.category}
+        </label>
         {categoryOptions.length === 0 ? (
           <p className={styles.muted}>{labels.noCategories}</p>
         ) : (
-          <fieldset className={styles.checkGroup}>
-            <legend className="sr-only">{labels.category}</legend>
-            {categoryOptions.map((category) => (
-              <label key={category.uuid} className={styles.check}>
-                <input
-                  type="checkbox"
-                  checked={selectedCategories.includes(category.uuid)}
-                  onChange={() => onCategoryToggle(category.uuid)}
-                />
-                <span>{category.name}</span>
-              </label>
-            ))}
-          </fieldset>
+          <CategorySelect
+            id="edit-category"
+            options={categoryOptions}
+            selected={selectedCategories}
+            ariaLabel={labels.category}
+            labels={{ placeholder: labels.categoryAdd, remove: labels.categoryRemove }}
+            onToggle={onCategoryToggle}
+          />
         )}
       </div>
 

--- a/src/components/forge/editor.module.css
+++ b/src/components/forge/editor.module.css
@@ -173,6 +173,25 @@
   padding: 0.2rem;
   background: transparent;
 }
+/* Category add-dropdown: a borderless select that sits inside the chip box like the
+   tag field, so the category picker reads as the same chip control. It rests on its
+   placeholder option (the control is controlled at value=""), so the muted colour
+   styles the "Add a category…" prompt. */
+.tagPicker {
+  flex: 1;
+  min-width: 9rem;
+  border: 0;
+  outline: none;
+  font: inherit;
+  padding: 0.2rem;
+  background: transparent;
+  color: var(--color-text-muted);
+  cursor: pointer;
+}
+.tagPicker:focus-visible {
+  box-shadow: var(--ring);
+  border-radius: 6px;
+}
 
 /* Save/Cancel as icon buttons in the editor's top-right corner — they sit at the
    right end of the tab bar, just above the tab underline, aligned with the tabs. */

--- a/src/components/forge/editorLabels.ts
+++ b/src/components/forge/editorLabels.ts
@@ -85,6 +85,8 @@ export function buildEditorLabels(t: (key: string) => string): Labels {
       status: t("editor.metadata.status"),
       category: t("editor.metadata.category"),
       noCategories: t("editor.metadata.noCategories"),
+      categoryAdd: t("editor.metadata.categoryAdd"),
+      categoryRemove: t("editor.metadata.categoryRemove"),
       tags: t("editor.metadata.tags"),
       tag: {
         add: t("editor.metadata.tag.add"),


### PR DESCRIPTION
Three small storefront/editor UX fixes for SECURITY-571.

## Changes
1. **Slow the filter loading bar** — the indeterminate nav-progress sliver looped every `1.05s`, reading as frantic while a filtered page loads. Slowed the slide cycle to `1.9s` (transform-only motion + reduced-motion fallback unchanged).
2. **Clearing the header search re-applies the filter** — the native `type="search"` "×" empties the field but never submitted, so the old keyword filter lingered until the user pressed Enter. `AdvancedSearchSync` now listens for the input's `search` event and submits the header form when cleared. Because the island already injects the active status/category facets as hidden inputs, **clearing the keyword keeps the facet selection**. Gated on an active `src_terms` in the URL so it fires only on a genuine clear and never double-submits alongside the browser's own Enter submit.
3. **Category picker now looks like the tag selector** — the editor's category field was a checkbox list, visually unlike the adjacent tag editor. New `CategorySelect` renders selected categories as removable chips (same chip styling as tags) with a borderless dropdown to add from the remaining options. Categories are a fixed set (the store's category tree), so the add control is a constrained `<select>` rather than free text; one `onToggle` handles both add and remove. New i18n: `editor.metadata.categoryAdd` / `categoryRemove` (en + fr).

## Test plan
- Cypress E2E (paired tests in `privateappstore`): full suite **121/121** green, incl. `16-storefront` 24/24 (clear-search drops keyword / keeps facet) and `17-authoring` 22/22 (category chip pick → chip → remove). Accessibility AAA gate (`20-accessibility`) still green with the new control.
- `npm run build` green.