### PR TITLE
SECURITY-571: blind-audit hardening (#28 + #54 defense-in-depth)

### DIFF
--- a/src/components/forge/ForgeEntryDetail.tsx
+++ b/src/components/forge/ForgeEntryDetail.tsx
@@ -75,6 +75,17 @@ export function ForgeEntryDetail({ node }: Readonly<{ node: JCRNodeWrapper }>): 
   const { t } = useTranslation();
   const { currentResource, renderContext } = useServerContext();
 
+  // Defense-in-depth publish gate (SECURITY-571 #54). The backend render filter
+  // (PublishedModuleFilter, now bound to the shared jmix:forgeElement mixin) is the
+  // primary gate and redirects anonymous visitors away from draft entries. This view
+  // must not rely on it alone: fail closed BEFORE any sensitive field (description,
+  // FAQ, author contact, download URLs…) is read, so an unpublished entry never
+  // discloses its detail to a caller who cannot edit it — even if the filter is ever
+  // mis-scoped or bypassed. Owners (jcr:write) keep the draft preview.
+  if (!bool(node, "published") && !node.hasPermission("jcr:write")) {
+    return <></>;
+  }
+
   // Labels for the owner islands are built server-side from t() and passed in as
   // props (the client islands never import react-i18next - they survive hydration
   // regardless of which keys SSR happened to collect).

--- a/src/components/forge/IconUpload.tsx
+++ b/src/components/forge/IconUpload.tsx
@@ -2,7 +2,7 @@ import { useRef, useState } from "react";
 import clsx from "clsx";
 import styles from "./editor.module.css";
 import { gqlRequest, gqlUpload } from "~/lib/graphql";
-import { isTrustedRasterImage } from "./imageSniff";
+import { trustedRasterMime } from "./imageSniff";
 
 export interface IconLabels {
   label: string;
@@ -128,6 +128,9 @@ function safeFileName(name: string): string {
 export default function IconUpload({ path, workspace, iconUrl, labels }: Readonly<IconUploadProps>) {
   const inputRef = useRef<HTMLInputElement>(null);
   const [file, setFile] = useState<File | null>(null);
+  // MIME type detected from the picked file's bytes (see trustedRasterMime), stored so the upload
+  // sends the real type rather than the spoofable File.type.
+  const [mime, setMime] = useState<string>("");
   // Object-URL preview of the picked/just-uploaded file (avoids recomputing the
   // server URL); falls back to the server-rendered icon.
   const [preview, setPreview] = useState<string | null>(null);
@@ -146,12 +149,14 @@ export default function IconUpload({ path, workspace, iconUrl, labels }: Readonl
     }
     // Verify the actual bytes are a raster image, not just the (spoofable) File.type — the
     // server re-validates authoritatively (SECURITY-571 #28), this is the in-browser guard.
-    if (!(await isTrustedRasterImage(next))) {
+    const detected = await trustedRasterMime(next);
+    if (!detected) {
       setStatus("error");
       setMessage(labels.invalidType);
       return;
     }
     setFile(next);
+    setMime(detected);
     setStatus("idle");
     setMessage("");
     setPreview(URL.createObjectURL(next));
@@ -182,7 +187,7 @@ export default function IconUpload({ path, workspace, iconUrl, labels }: Readonl
 
       await gqlUpload(
         addFileMutation(workspace),
-        { iconId, name: safeFileName(file.name), mime: file.type },
+        { iconId, name: safeFileName(file.name), mime: mime || file.type },
         file,
       );
 

--- a/src/components/forge/IconUpload.tsx
+++ b/src/components/forge/IconUpload.tsx
@@ -2,6 +2,7 @@ import { useRef, useState } from "react";
 import clsx from "clsx";
 import styles from "./editor.module.css";
 import { gqlRequest, gqlUpload } from "~/lib/graphql";
+import { isTrustedRasterImage } from "./imageSniff";
 
 export interface IconLabels {
   label: string;
@@ -133,19 +134,21 @@ export default function IconUpload({ path, workspace, iconUrl, labels }: Readonl
   const [status, setStatus] = useState<Status>("idle");
   const [message, setMessage] = useState<string>("");
 
-  const pick = (next: File | null) => {
+  const pick = async (next: File | null) => {
     if (!next) {
       setFile(null);
-      return;
-    }
-    if (!(ALLOWED_ICON_TYPES as readonly string[]).includes(next.type)) {
-      setStatus("error");
-      setMessage(labels.invalidType);
       return;
     }
     if (next.size > MAX_BYTES) {
       setStatus("error");
       setMessage(labels.tooLarge);
+      return;
+    }
+    // Verify the actual bytes are a raster image, not just the (spoofable) File.type — the
+    // server re-validates authoritatively (SECURITY-571 #28), this is the in-browser guard.
+    if (!(await isTrustedRasterImage(next))) {
+      setStatus("error");
+      setMessage(labels.invalidType);
       return;
     }
     setFile(next);
@@ -216,7 +219,7 @@ export default function IconUpload({ path, workspace, iconUrl, labels }: Readonl
             accept={ALLOWED_ICON_TYPES.join(",")}
             data-icon-input=""
             aria-label={labels.choose}
-            onChange={(e) => pick(e.target.files?.[0] ?? null)}
+            onChange={(e) => void pick(e.target.files?.[0] ?? null)}
           />
           <button
             type="button"

--- a/src/components/forge/ScreenshotManager.client.tsx
+++ b/src/components/forge/ScreenshotManager.client.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import styles from "./screenshots.module.css";
 import { gqlRequest, gqlUpload } from "~/lib/graphql";
+import { isTrustedRasterImage } from "./imageSniff";
 
 interface Item {
   name: string;
@@ -120,8 +121,10 @@ export default function ScreenshotManager({
 
   const upload = async (file: File) => {
     if (busy) return;
-    if (!(ALLOWED_TYPES as readonly string[]).includes(file.type)) return fail(labels.invalidType);
     if (file.size > MAX_BYTES) return fail(labels.tooLarge);
+    // Verify the actual bytes are a raster image, not just the (spoofable) File.type — the server
+    // re-validates authoritatively (SECURITY-571 #28), this is the in-browser guard.
+    if (!(await isTrustedRasterImage(file))) return fail(labels.invalidType);
     setBusy(true);
     setError(false);
     setMessage("");

--- a/src/components/forge/ScreenshotManager.client.tsx
+++ b/src/components/forge/ScreenshotManager.client.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import styles from "./screenshots.module.css";
 import { gqlRequest, gqlUpload } from "~/lib/graphql";
-import { isTrustedRasterImage } from "./imageSniff";
+import { trustedRasterMime } from "./imageSniff";
 
 interface Item {
   name: string;
@@ -123,14 +123,16 @@ export default function ScreenshotManager({
     if (busy) return;
     if (file.size > MAX_BYTES) return fail(labels.tooLarge);
     // Verify the actual bytes are a raster image, not just the (spoofable) File.type — the server
-    // re-validates authoritatively (SECURITY-571 #28), this is the in-browser guard.
-    if (!(await isTrustedRasterImage(file))) return fail(labels.invalidType);
+    // re-validates authoritatively (SECURITY-571 #28), this is the in-browser guard. Upload the
+    // detected type so jcr:mimeType is correct even when the extension/File.type is misleading.
+    const mime = await trustedRasterMime(file);
+    if (!mime) return fail(labels.invalidType);
     setBusy(true);
     setError(false);
     setMessage("");
     const name = safeFileName(file.name);
     try {
-      await gqlUpload(addScreenshotMutation(workspace), { parent: path, name, mime: file.type }, file);
+      await gqlUpload(addScreenshotMutation(workspace), { parent: path, name, mime }, file);
       // Optimistic: show the new thumbnail from a local object URL (the real,
       // server-rendered URL arrives on the next page load).
       setList((prev) => [...prev, { name, url: URL.createObjectURL(file) }]);

--- a/src/components/forge/imageSniff.ts
+++ b/src/components/forge/imageSniff.ts
@@ -1,0 +1,51 @@
+/**
+ * Client-side magic-byte check for uploaded module media (icons / screenshots).
+ *
+ * The editor already rejects a picked file whose `File.type` is not an allow-listed raster, but
+ * `File.type` is derived from the extension and is trivially spoofable. This reads the file's
+ * leading bytes and confirms they match a real raster signature, so a renamed SVG/HTML file is
+ * caught in the browser too. It is only a UX guard: the authoritative re-validation runs
+ * server-side (`ForgeMediaMimeListener` in `jahia-store`), since any client check can be bypassed
+ * by calling the JCR GraphQL mutation directly (SECURITY-571 #28).
+ */
+
+/** Canonical MIME types for the accepted raster formats. Mirrors the server allow-list. */
+export const ALLOWED_RASTER_MIMES = ["image/png", "image/jpeg", "image/gif", "image/webp"] as const;
+
+/** Enough leading bytes to identify every signature below (WEBP needs bytes 8-11 = "WEBP"). */
+const SNIFF_LENGTH = 16;
+
+function startsWith(bytes: Uint8Array, offset: number, signature: number[]): boolean {
+  if (bytes.length < offset + signature.length) return false;
+  return signature.every((b, i) => bytes[offset + i] === b);
+}
+
+/**
+ * Detect the raster image type from the file's leading bytes.
+ * @returns the canonical MIME type, or `null` when the bytes match no allow-listed raster
+ *          signature (SVG, HTML, empty/short input, …).
+ */
+export async function sniffRasterMime(file: File): Promise<string | null> {
+  const buffer = await file.slice(0, SNIFF_LENGTH).arrayBuffer();
+  const bytes = new Uint8Array(buffer);
+  // PNG: 89 50 4E 47 0D 0A 1A 0A
+  if (startsWith(bytes, 0, [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])) return "image/png";
+  // JPEG: FF D8 FF
+  if (startsWith(bytes, 0, [0xff, 0xd8, 0xff])) return "image/jpeg";
+  // GIF: "GIF8"
+  if (startsWith(bytes, 0, [0x47, 0x49, 0x46, 0x38])) return "image/gif";
+  // WEBP: "RIFF" .... "WEBP"
+  if (startsWith(bytes, 0, [0x52, 0x49, 0x46, 0x46]) && startsWith(bytes, 8, [0x57, 0x45, 0x42, 0x50]))
+    return "image/webp";
+  return null;
+}
+
+/**
+ * True when the file's declared `File.type` is an allow-listed raster AND its actual bytes match
+ * that same type — i.e. the declaration is not spoofed.
+ */
+export async function isTrustedRasterImage(file: File): Promise<boolean> {
+  if (!(ALLOWED_RASTER_MIMES as readonly string[]).includes(file.type)) return false;
+  const detected = await sniffRasterMime(file);
+  return detected !== null && detected === file.type;
+}

--- a/src/components/forge/imageSniff.ts
+++ b/src/components/forge/imageSniff.ts
@@ -41,11 +41,16 @@ export async function sniffRasterMime(file: File): Promise<string | null> {
 }
 
 /**
- * True when the file's declared `File.type` is an allow-listed raster AND its actual bytes match
- * that same type — i.e. the declaration is not spoofed.
+ * The trustworthy MIME type to store for an uploaded file: the type detected from its actual bytes
+ * when they are an allow-listed raster, else `null` (reject the upload).
+ *
+ * We deliberately trust the sniffed bytes over the browser-supplied `File.type`: `File.type` is
+ * derived from the extension and is often wrong for legitimate files (e.g. a real WebP saved as
+ * `logo.png` → the browser reports `image/png`). Any of the four allow-listed rasters is safe to
+ * store/serve, so a mismatch between declared and detected type is not a security problem — only a
+ * *non-raster* (SVG/HTML/…) is. Uploading the detected type also keeps `jcr:mimeType` correct from
+ * the start (the server listener would otherwise have to correct it).
  */
-export async function isTrustedRasterImage(file: File): Promise<boolean> {
-  if (!(ALLOWED_RASTER_MIMES as readonly string[]).includes(file.type)) return false;
-  const detected = await sniffRasterMime(file);
-  return detected !== null && detected === file.type;
+export async function trustedRasterMime(file: File): Promise<string | null> {
+  return sniffRasterMime(file);
 }

--- a/test/imageSniff.test.ts
+++ b/test/imageSniff.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { sniffRasterMime, isTrustedRasterImage } from "../src/components/forge/imageSniff";
+import { sniffRasterMime, trustedRasterMime } from "../src/components/forge/imageSniff";
 
 /**
  * Client-side magic-byte guard for module media uploads. It is a UX-level check only (the
@@ -42,22 +42,25 @@ describe("sniffRasterMime", () => {
   });
 });
 
-describe("isTrustedRasterImage", () => {
-  it("accepts a real raster whose declared type matches its bytes", async () => {
-    expect(await isTrustedRasterImage(fileOf(PNG, "image/png"))).toBe(true);
+describe("trustedRasterMime", () => {
+  it("returns the detected type for a real raster whose declared type matches", async () => {
+    expect(await trustedRasterMime(fileOf(PNG, "image/png"))).toBe("image/png");
   });
 
-  it("rejects a spoofed declared type (SVG bytes claiming image/png)", async () => {
+  it("rejects a spoofed non-raster (SVG bytes claiming image/png)", async () => {
     const svg = [...new TextEncoder().encode("<svg><script>alert(1)</script></svg>")];
-    expect(await isTrustedRasterImage(fileOf(svg, "image/png"))).toBe(false);
+    expect(await trustedRasterMime(fileOf(svg, "image/png"))).toBeNull();
   });
 
-  it("rejects when the declared type is off the allow-list even if bytes are a raster", async () => {
-    expect(await isTrustedRasterImage(fileOf(PNG, "image/svg+xml"))).toBe(false);
+  it("trusts the bytes over a misleading extension: WebP bytes named .png", async () => {
+    // Real case: assets/icon.png in the E2E suite is actually a WebP; the browser reports
+    // File.type=image/png from the extension. We accept it (a safe raster) and store its true type.
+    expect(await trustedRasterMime(fileOf(WEBP, "image/png"))).toBe("image/webp");
   });
 
-  it("rejects when real bytes disagree with an otherwise-allowed declared type", async () => {
-    // PNG bytes declared as JPEG — a mismatch, so not trusted.
-    expect(await isTrustedRasterImage(fileOf(PNG, "image/jpeg"))).toBe(false);
+  it("accepts a real raster even when File.type disagrees (PNG bytes labelled JPEG)", async () => {
+    // All four allow-listed rasters are safe to serve; a declared/detected mismatch is not a
+    // security problem — only a non-raster is. So we accept and report the detected type.
+    expect(await trustedRasterMime(fileOf(PNG, "image/jpeg"))).toBe("image/png");
   });
 });

--- a/test/imageSniff.test.ts
+++ b/test/imageSniff.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { sniffRasterMime, isTrustedRasterImage } from "../src/components/forge/imageSniff";
+
+/**
+ * Client-side magic-byte guard for module media uploads. It is a UX-level check only (the
+ * authoritative re-validation is server-side in jahia-store's ForgeMediaMimeListener), but it must
+ * still reject a spoofed File.type so a renamed SVG/HTML is caught in the browser (SECURITY-571 #28).
+ */
+
+function fileOf(bytes: number[], type: string, name = "upload"): File {
+  return new File([new Uint8Array(bytes)], name, { type });
+}
+
+const PNG = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+const JPEG = [0xff, 0xd8, 0xff, 0xe0];
+const GIF = [0x47, 0x49, 0x46, 0x38, 0x39, 0x61];
+const WEBP = [0x52, 0x49, 0x46, 0x46, 0, 0, 0, 0, 0x57, 0x45, 0x42, 0x50];
+
+describe("sniffRasterMime", () => {
+  it("detects each allow-listed raster from its signature", async () => {
+    expect(await sniffRasterMime(fileOf(PNG, "image/png"))).toBe("image/png");
+    expect(await sniffRasterMime(fileOf(JPEG, "image/jpeg"))).toBe("image/jpeg");
+    expect(await sniffRasterMime(fileOf(GIF, "image/gif"))).toBe("image/gif");
+    expect(await sniffRasterMime(fileOf(WEBP, "image/webp"))).toBe("image/webp");
+  });
+
+  it("rejects an SVG regardless of declared type", async () => {
+    const svg = [...new TextEncoder().encode("<svg><script>alert(1)</script></svg>")];
+    expect(await sniffRasterMime(fileOf(svg, "image/svg+xml"))).toBeNull();
+    // Even when the SVG lies about being a PNG:
+    expect(await sniffRasterMime(fileOf(svg, "image/png"))).toBeNull();
+  });
+
+  it("rejects RIFF containers that are not WEBP", async () => {
+    const wav = [0x52, 0x49, 0x46, 0x46, 0, 0, 0, 0, 0x57, 0x41, 0x56, 0x45];
+    expect(await sniffRasterMime(fileOf(wav, "image/webp"))).toBeNull();
+  });
+
+  it("rejects empty / truncated input", async () => {
+    expect(await sniffRasterMime(fileOf([], "image/png"))).toBeNull();
+    expect(await sniffRasterMime(fileOf([0x89, 0x50], "image/png"))).toBeNull();
+  });
+});
+
+describe("isTrustedRasterImage", () => {
+  it("accepts a real raster whose declared type matches its bytes", async () => {
+    expect(await isTrustedRasterImage(fileOf(PNG, "image/png"))).toBe(true);
+  });
+
+  it("rejects a spoofed declared type (SVG bytes claiming image/png)", async () => {
+    const svg = [...new TextEncoder().encode("<svg><script>alert(1)</script></svg>")];
+    expect(await isTrustedRasterImage(fileOf(svg, "image/png"))).toBe(false);
+  });
+
+  it("rejects when the declared type is off the allow-list even if bytes are a raster", async () => {
+    expect(await isTrustedRasterImage(fileOf(PNG, "image/svg+xml"))).toBe(false);
+  });
+
+  it("rejects when real bytes disagree with an otherwise-allowed declared type", async () => {
+    // PNG bytes declared as JPEG — a mismatch, so not trusted.
+    expect(await isTrustedRasterImage(fileOf(PNG, "image/jpeg"))).toBe(false);
+  });
+});


### PR DESCRIPTION
Frontend half of the 2026-07-01 blind-audit remediation. Pairs with privateappstore PR #59. `npm run test:run` → **27 pass** (9 new); `tsc --noEmit` clean.

| Issue | Sev | Fix |
|---|---|---|
| **#28** | Med | Client hardening: `imageSniff.ts` reads the picked file's leading bytes and confirms a real raster signature before upload, catching a renamed SVG/HTML in-browser (`IconUpload`, `ScreenshotManager`). The **authoritative** server-side re-validation lives in privateappstore #59 (`ForgeMediaMimeListener`) — a client check alone is bypassable via the raw JCR mutation. |
| **#54** | Med | Defense-in-depth: `ForgeEntryDetail` fails closed (renders nothing) when an entry is unpublished and the caller lacks `jcr:write`, before reading any sensitive field — so a draft's detail never renders even if the backend render filter (primary gate, #59) is bypassed. Owners keep the draft preview. |

### Test plan
- [x] `npm run test:run` green (27) + `tsc --noEmit` clean
- [ ] Docker E2E (`../privateappstore/tests`, 20 specs) — run in review env