### PR TITLE
ci: add release workflow (GitHub pre-release -> Nexus)

### DIFF
--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -1,0 +1,59 @@
+# This workflow is triggered when someone creates a new release in GitHub
+# and checks the "This is a pre-release" box.
+name: Trigger Release creation
+
+on:
+  release:
+    types: [prereleased]
+
+jobs:
+  on-release:
+    runs-on: ubuntu-latest
+
+    # The cimg-mvn-cache is an image containing a .m2 folder warmed-up
+    # with common Jahia dependencies. Using this prevents maven from
+    # downloading the entire world when building.
+    # More on https://github.com/Jahia/cimg-mvn-cache
+    container:
+      image: ghcr.io/jahia/jahia-docker-mvn-cache:11-jdk-noble-mvn-loaded
+      credentials:
+        username: ${{ secrets.GH_PACKAGES_USERNAME }}
+        password: ${{ secrets.GH_PACKAGES_TOKEN }}
+
+    steps:
+      # Register the workspace as a git safe directory. A stricter git in the
+      # runner image otherwise aborts the release with "detected dubious
+      # ownership" (exit 128) before Maven runs. Must precede checkout.
+      - name: Add safe directory
+        shell: bash
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      # Providing the SSH PRIVATE key of a user in an admin group is necessary
+      # to bypass PR checks and let the release commit the version bump back.
+      - uses: actions/checkout@v4
+        with:
+          ssh-key: ${{ secrets.GH_SSH_PRIVATE_KEY_JAHIACI }}
+
+      # Setting up the SSH agent to be able to commit back to the repository
+      # https://github.com/webfactory/ssh-agent
+      - uses: webfactory/ssh-agent@v0.5.4
+        with:
+          ssh-private-key: ${{ secrets.GH_SSH_PRIVATE_KEY_JAHIACI }}
+
+      - uses: jahia/jahia-modules-action/release@v2
+        name: Release Module
+        with:
+          github_slug: Jahia/store-template
+          primary_release_branch: master
+          release_id: ${{ github.event.release.id }}
+          release_version: ${{ github.event.release.tag_name }}
+          github_api_token: ${{ secrets.GH_API_TOKEN }}
+          nexus_username: ${{ secrets.NEXUS_USERNAME }}
+          nexus_password: ${{ secrets.NEXUS_PASSWORD }}
+
+      - uses: jahia/jahia-modules-action/update-signature@v2
+        with:
+          nexus_username: ${{ secrets.NEXUS_USERNAME }}
+          nexus_password: ${{ secrets.NEXUS_PASSWORD }}
+          force_signature: true


### PR DESCRIPTION
store-template had **no CI** — releases were cut locally via `maven-release-plugin`. This adds an `on-release.yml` mirroring the JS-module release pattern (`richtext-ckeditor5`): creating a GitHub **pre-release** triggers `jahia-modules-action/release@v2` + `update-signature`, so store-template releases like the other Jahia modules.

Includes the git `safe.directory` step (before checkout) that the current runner image requires — same fix as privateappstore #60.

**Prerequisites before it can release:**
- The repo/org must expose the standard Jahia release secrets (CI SSH key, Nexus username/password, API + packages tokens). The Nexus password currently blank for privateappstore must be set.
- Known cosmetic desync: `package.json` (5.0.0-SNAPSHOT) vs pom (5.0.1-SNAPSHOT); the deployed artifact version derives from the pom, so it doesn't block the release but should be reconciled.