### PR TITLE
fix: sync package.json version to the pom (5.0.1-SNAPSHOT)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jahia-store-template",
-  "version": "5.0.0-SNAPSHOT",
+  "version": "5.0.1-SNAPSHOT",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jahia-store-template",
-      "version": "5.0.0-SNAPSHOT",
+      "version": "5.0.1-SNAPSHOT",
       "license": "Apache-2.0",
       "dependencies": {
         "@fontsource-variable/nunito-sans": "^5.2.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jahia-store-template",
-  "version": "5.0.0-SNAPSHOT",
+  "version": "5.0.1-SNAPSHOT",
   "license": "Apache-2.0",
   "type": "module",
   "description": "Jahia Store Template - JavaScript module (SSR React via javascript-modules-engine).",


### PR DESCRIPTION
Fixes the package.json↔pom version desync at the source (companion to privateappstore #64).

A Jahia JS module's deployed OSGi version comes from `package.json`, so with `package.json` at `5.0.0-SNAPSHOT` and the pom at `5.0.1-SNAPSHOT`, the module deployed as **5.0.0-SNAPSHOT** — lagging every other version source. That's what made the E2E `01-modulesInstalled` version check fail (it looked for jahia-store-template/5.0.1 and found the module at 5.0.0).

Bumps `package.json` + `package-lock.json` root version to `5.0.1-SNAPSHOT`. Verified: `npm pack` now emits `jahia-store-template-5.0.1-SNAPSHOT.tgz` and `npm ci` is in sync.

Note: recurs on the next maven-release (which bumps only the pom); a build-time sync would remove it permanently — follow-up if wanted.