### PR TITLE
SUPPORT-659: hide draft versions from non-owners + sync release versioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ node_modules/
 !.yarn/releases
 *.tgz
 .vite/
+
+# Claude Code personal overrides
+.claude/settings.local.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jahia-store-template",
-  "version": "5.0.2-SNAPSHOT",
+  "version": "5.0.3-SNAPSHOT",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jahia-store-template",
-      "version": "5.0.2-SNAPSHOT",
+      "version": "5.0.3-SNAPSHOT",
       "license": "Apache-2.0",
       "dependencies": {
         "@fontsource-variable/nunito-sans": "^5.2.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jahia-store-template",
-  "version": "5.0.2-SNAPSHOT",
+  "version": "5.0.3-SNAPSHOT",
   "license": "Apache-2.0",
   "type": "module",
   "description": "Jahia Store Template - JavaScript module (SSR React via javascript-modules-engine).",

--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,57 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+                <version>3.1.1</version>
+                <configuration>
+                    <preparationGoals>-P release-prepare clean verify scm:checkin</preparationGoals>
+                    <completionGoals>-P release-prepare clean install scm:checkin</completionGoals>
+                    <useReleaseProfile>false</useReleaseProfile>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
+    <profiles>
+        <!-- Only active when explicitly passed -P release-prepare (by maven-release-plugin's
+             preparationGoals/completionGoals above) - never during a normal build. -->
+        <profile>
+            <id>release-prepare</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <version>3.1.0</version>
+                        <executions>
+                            <execution>
+                                <id>sync-package-json-version</id>
+                                <phase>validate</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <executable>node</executable>
+                                    <arguments>
+                                        <argument>sync-version.js</argument>
+                                        <argument>${project.version}</argument>
+                                    </arguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-scm-plugin</artifactId>
+                        <version>2.1.0</version>
+                        <configuration>
+                            <includes>package.json,package-lock.json</includes>
+                            <message>chore: sync package.json version to ${project.version} [skip ci]</message>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/settings/locales/en.json
+++ b/settings/locales/en.json
@@ -68,7 +68,7 @@
   "upload": {
     "signInPrompt": "Please log in to submit a module.",
     "repoUnavailable": "The module repository is not available on this site.",
-    "fileLabel": "Module package (.jar)",
+    "fileLabel": "Module package (.jar or .tgz)",
     "submit": "Upload module",
     "submitting": "Uploading…",
     "pickFile": "Please choose a module package first.",
@@ -201,7 +201,7 @@
     }
   },
   "addVersion": {
-    "fileLabel": "New version package (.jar)",
+    "fileLabel": "New version package (.jar or .tgz)",
     "submit": "Upload new version",
     "submitting": "Uploading…",
     "pickFile": "Please choose a module package first.",

--- a/settings/locales/fr.json
+++ b/settings/locales/fr.json
@@ -68,7 +68,7 @@
   "upload": {
     "signInPrompt": "Veuillez vous connecter pour soumettre un module.",
     "repoUnavailable": "Le dépôt de modules n'est pas disponible sur ce site.",
-    "fileLabel": "Paquet du module (.jar)",
+    "fileLabel": "Paquet du module (.jar ou .tgz)",
     "submit": "Téléverser le module",
     "submitting": "Téléversement…",
     "pickFile": "Veuillez d'abord choisir un paquet de module.",
@@ -201,7 +201,7 @@
     }
   },
   "addVersion": {
-    "fileLabel": "Paquet de la nouvelle version (.jar)",
+    "fileLabel": "Paquet de la nouvelle version (.jar ou .tgz)",
     "submit": "Téléverser la nouvelle version",
     "submitting": "Téléversement…",
     "pickFile": "Veuillez d'abord choisir un paquet de module.",

--- a/src/components/FileUpload/default.server.tsx
+++ b/src/components/FileUpload/default.server.tsx
@@ -45,7 +45,7 @@ jahiaComponent(
     return (
       <Island
         component={FileUploadForm}
-        props={{ actionUrl, backUrl: back, accept: ".jar", labels }}
+        props={{ actionUrl, backUrl: back, accept: ".jar,.tgz", labels }}
       />
     );
   },

--- a/src/components/forge/DetailVersionsDialog.tsx
+++ b/src/components/forge/DetailVersionsDialog.tsx
@@ -61,7 +61,7 @@ export function DetailVersionsDialog({
               props={{
                 actionUrl: uploadActionUrl,
                 backUrl,
-                accept: ".jar",
+                accept: ".jar,.tgz",
                 labels: ADD_VERSION_LABELS,
                 compact: true,
               }}

--- a/src/components/forge/ForgeEntryDetail.tsx
+++ b/src/components/forge/ForgeEntryDetail.tsx
@@ -110,11 +110,13 @@ export function ForgeEntryDetail({ node }: Readonly<{ node: JCRNodeWrapper }>): 
   const icon = forgeIconUrl(node);
   const shots = screenshotItems(node);
   const screenshotsPath = node.hasNode("screenshots") ? node.getNode("screenshots").getPath() : "";
-  const versions = sortedVersionNodes(node);
   const videoNode = node.hasNode("video") ? node.getNode("video") : null;
   const videoProvider = videoNode ? str(videoNode, "provider") : "";
   const videoId = videoNode ? str(videoNode, "identifier") : "";
   const canEdit = node.hasPermission("jcr:write");
+  // Owners manage drafts from this list; everyone else only ever sees released
+  // versions - mirrors the module-level published gate above (line 85).
+  const versions = sortedVersionNodes(node).filter((v) => canEdit || bool(v, "published"));
   const language = currentResource.getLocale().getLanguage();
   const published = bool(node, "published");
   const workspace = jcrWorkspace(node);

--- a/sync-version.js
+++ b/sync-version.js
@@ -1,6 +1,11 @@
 import fs from "node:fs";
 
-const updated = fs
-  .readFileSync("package.json", "utf8")
-  .replace(/"version": ".+"/, `"version": ${JSON.stringify(process.argv[2])}`);
+const original = fs.readFileSync("package.json", "utf8");
+const updated = original.replace(/"version": "[^"]+"/, `"version": ${JSON.stringify(process.argv[2])}`);
+
+if (updated === original) {
+  console.error(`sync-version.js: no "version" field matched in package.json (target: ${process.argv[2]})`);
+  process.exit(1);
+}
+
 fs.writeFileSync("package.json", updated);

--- a/sync-version.js
+++ b/sync-version.js
@@ -1,0 +1,6 @@
+import fs from "node:fs";
+
+const updated = fs
+  .readFileSync("package.json", "utf8")
+  .replace(/"version": ".+"/, `"version": ${JSON.stringify(process.argv[2])}`);
+fs.writeFileSync("package.json", updated);


### PR DESCRIPTION
## Summary
- **Bug fix**: `sortedVersionNodes()` returned every module/package version unconditionally, so once a module cleared the module-level `published` gate, any additional draft/unpublished version underneath it (changelog, release metadata, and a working download link for the unreleased artifact) was fully visible to anonymous guests - including as the prominent header "latest download" CTA, which picks `versions[0]`. `ForgeEntryDetail.tsx` now filters to `canEdit || published`: owners keep seeing/managing drafts, everyone else only sees released versions.
- **Release tooling**: `mvn release:prepare`/`release:perform` only ever rewrote this pom's `<version>` - zero awareness of `package.json`, the JS module's actual version descriptor (read by Jahia's tgz->OSGi conversion and `createEntryFromJar`). Added `sync-version.js` + a `release-prepare` Maven profile, wired into `maven-release-plugin`'s `preparationGoals`/`completionGoals`, so a plain `mvn release:prepare` keeps both files in lockstep automatically (pattern documented in the `jahia-developer-js` skill, proven on `javascript-modules-library`). Also corrects `package.json`/`package-lock.json`, which had drifted to `5.0.2-SNAPSHOT` while `pom.xml` had already moved to `5.0.3-SNAPSHOT`.
- **Upload UX fix**: `createEntryFromJar` has supported both `.jar` and `.tgz` archives for a while, but the module-upload and new-version-upload forms restricted the OS file picker's `accept` attribute to `.jar` only, making `.tgz` uploads awkward (and easy to bypass by typing the filename directly). Widened `accept` to `.jar,.tgz` in `FileUpload/default.server.tsx` and `DetailVersionsDialog.tsx`, and updated the corresponding `fileLabel` copy in `en.json`/`fr.json` to read "(.jar or .tgz)".

## Test plan
- [x] New Cypress spec in the sibling `privateappstore` repo (`tests/cypress/e2e/22-versionVisibility.cy.ts`, not part of this PR) exercises the visibility fix: owner sees both a released and a draft version in the popup; anonymous guest sees only the released version, with no draft changelog/download URL anywhere in the HTML, and the header CTA pointing at the released version.
- [x] Full 21-spec `privateappstore` Cypress suite run against this branch's built artifact: new spec 2/2, `16-storefront.cy.ts` 24/24, `17-authoring.cy.ts` 22/22 (closest existing coverage - no regressions). One unrelated pre-existing smoke-test flake in `01-modulesInstalled.cy.ts` (bundle-version-string check), not caused by this change.
- [x] `mvn -P release-prepare validate` run directly to confirm the sync wiring fires correctly (stops before any build/git/tag/push step).
- [x] Manual check that both upload forms now accept `.tgz` files in the OS file picker and successfully upload (not yet re-verified after the accept-attribute change).
